### PR TITLE
docs: add EmDash migration research and domain context

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,13 @@
+# Carte des contextes
+
+## Contextes
+
+- [Plateforme SuperBoard](./CONTEXT.md) — vocabulaire transversal de la plateforme et de sa migration vers EmDash.
+- [Applications](./apps/CONTEXT.md) — surfaces interactives rendues aux opérateurs et aux utilisateurs SuperBoard.
+- [Workers](./workers/CONTEXT.md) — runtimes métier et données opérationnelles des modules SuperBoard.
+
+## Relations
+
+- **Applications → Plateforme SuperBoard** : le Front SuperBoard consomme une Release Front publiée par le Site EmDash.
+- **Applications → Workers** : les actions et sources de données déclarées par les plugins modules appellent leurs Workers métier.
+- **Plateforme SuperBoard → Workers** : le Site EmDash configure les plugins modules et contrôle leur disponibilité avant publication d’une Release Front.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# Plateforme SuperBoard
+
+Ce contexte définit le vocabulaire transversal de SuperBoard en tant que site EmDash, sans décrire son implémentation.
+
+## Langage
+
+**Site EmDash** :
+Site déployable qui réunit le CMS EmDash, son administration interne et le Front SuperBoard qu’il publie.
+_À éviter_ : Dashboard EmDash, SuperBoard monolithique
+
+**EmDash Admin** :
+Surface interne du Site EmDash utilisée par les opérateurs de plateforme pour construire, configurer et publier SuperBoard.
+_À éviter_ : SuperBoard Admin, front utilisateur
+
+**Front SuperBoard** :
+Ensemble des surfaces destinées aux utilisateurs SuperBoard, qu’elles soient anonymes, authentifiées ou dans un état système.
+_À éviter_ : EmDash Admin, Dashboard EmDash
+
+**Release Front** :
+Représentation complète, immuable et validée du Front SuperBoard publiée atomiquement par le Site EmDash.
+_À éviter_ : draft, page partielle
+
+**Plugin full EmDash** :
+Plugin `supbrd-plug-*` dont l’exécution et les données appartiennent entièrement au Site EmDash.
+_À éviter_ : plugin module, Worker métier
+
+**Plugin module** :
+Plugin `supbrd-plugmod-*` configuré dans EmDash et associé à un Worker pour son runtime métier ou asynchrone.
+_À éviter_ : plugin full EmDash, Worker autonome
+
+**Core SuperBoard** :
+Plugin fondateur `supbrd-core` qui fournit les primitives et le runtime générique du Front SuperBoard sans posséder de page concrète.
+_À éviter_ : application SuperBoard, collection de pages

--- a/apps/CONTEXT.md
+++ b/apps/CONTEXT.md
@@ -1,0 +1,17 @@
+# Applications SuperBoard
+
+Ce contexte nomme les surfaces interactives du Site EmDash et du produit SuperBoard.
+
+## Langage
+
+**SuperBoard Login** :
+Partie anonyme du Front SuperBoard qui permet d’établir ou de récupérer une session utilisateur.
+_À éviter_ : login EmDash Admin
+
+**SuperBoard Admin** :
+Partie authentifiée du Front SuperBoard dans laquelle les utilisateurs exploitent les fonctions du produit.
+_À éviter_ : EmDash Admin, back-office EmDash
+
+**Dashboard historique** :
+Application SuperBoard antérieure au Site EmDash, conservée uniquement tant que la parité et le retour arrière de la migration l’exigent.
+_À éviter_ : Front SuperBoard cible

--- a/docs/EMDASH_CAPABILITY_AUDIT_2026-08-29.md
+++ b/docs/EMDASH_CAPABILITY_AUDIT_2026-08-29.md
@@ -1,0 +1,583 @@
+# Audit des capacités et limites d’EmDash pour la migration SuperBoard
+
+- Ticket de recherche : [Auditer les capacités et les limites actuelles d’EmDash](https://github.com/mabzadev/superboard/issues/44)
+- Carte Wayfinder : [Migration complète de SuperBoard vers EmDash CMS](https://github.com/mabzadev/superboard/issues/33)
+- Date de l’audit : 29 août 2026
+- Dépôt audité : [`emdash-cms/emdash`](https://github.com/emdash-cms/emdash)
+- Commit audité, immuable : [`1717d31b351164a5f78e95fe004ee582c7c50f40`](https://github.com/emdash-cms/emdash/commit/1717d31b351164a5f78e95fe004ee582c7c50f40)
+- Version déclarée des paquets principaux à ce commit : `0.35.0` pour `emdash`, `@emdash-cms/admin` et `@emdash-cms/cloudflare`.[^pkg-core][^pkg-admin][^pkg-cloudflare]
+
+## Résultat
+
+EmDash fournit déjà un socle CMS substantiel et directement exploitable : une administration React montée dans un site Astro, un modèle de contenu dynamique en base, des collections et champs typés, Portable Text, médias, menus, taxonomies, sections, zones de widgets, authentification, RBAC, révisions et publication par entrée, API REST, CLI, plugins natifs ou sandboxés, stockage et KV par plugin, hooks, routes, pages d’administration, widgets et blocs.[^readme-features][^admin-screens][^schema-types][^plugin-overview]
+
+EmDash ne fournit pas la cible « Release Front SuperBoard ». Au commit audité, il n’existe ni modèle canonique de pages/layouts/éléments/actions/data sources du front produit, ni registre générique de renderers publics, ni validateur inter-plugins, ni artefact de release front immuable, ni pointeur d’activation atomique, ni rollback de release, ni descripteur de Worker métier avec santé et migrations. Cette conclusion ne repose pas seulement sur une recherche lexicale : les surfaces exhaustives de `PluginDescriptor`, `PluginManifest`, `PluginContext` et des noms de hooks s’arrêtent aux primitives CMS et plugins détaillées ci-dessous.[^plugin-descriptor][^plugin-manifest][^plugin-context][^hook-names]
+
+La différence déterminante est la suivante :
+
+- EmDash sait publier atomiquement **une entrée de contenu** et conserver ses révisions.[^content-publish]
+- L’action « bulk publish » de l’administration lance **une requête par entrée**, avec cinq requêtes au maximum en parallèle ; ce n’est pas une transaction de site.[^bulk-publish]
+- Les menus, zones de widgets, widgets, sections, options et états de plugins sont stockés comme des lignes actives sans pointeurs draft/live comparables à ceux des collections de contenu.[^live-resource-tables]
+- EmDash n’a donc pas de promotion atomique d’un ensemble cohérent de routes, pages, layouts, permissions, textes, médias et contributions de plugins.
+
+EmDash est en **beta preview** et ses paquets principaux audités (`emdash`, admin et adapter Cloudflare) sont encore pré-1.0. Le registre de plugins et son contrat partagé sont explicitement expérimentaux ; plusieurs noms de capacités sont dans une fenêtre de migration ; la documentation et le code présentent quelques divergences de configuration. Une migration complète doit donc épingler exactement la version évaluée et traiter les surfaces expérimentales comme changeantes, mais cet audit ne choisit pas encore de stratégie d’intégration.[^readme-status][^pkg-core][^pkg-admin][^pkg-cloudflare][^plugin-types-experimental][^registry-experimental][^capability-transition]
+
+## Méthode et sens des classifications
+
+Le dépôt officiel a été cloné intégralement, sans clone superficiel, avec tous les packages, applications, démos, templates, documentation et historique disponibles. L’audit a lu le code et la documentation officiels au SHA indiqué ; les permaliens de ce document pointent toujours vers ce SHA.
+
+Les termes ont ici un sens strict :
+
+- **Existe** : la capacité est implémentée et exposée dans le commit audité.
+- **Adaptable** : une primitive existe et peut contribuer à la cible, mais elle ne satisfait pas à elle seule le contrat SuperBoard. Ce qualificatif ne constitue pas une recommandation d’architecture.
+- **Manque** : aucune surface correspondante n’apparaît dans les contrats publics exhaustifs ou dans les implémentations auditées ; un développement ou une extension de contrat est requis.
+- **Instable** : la capacité est explicitement bêta/expérimentale, en transition, ou la documentation officielle ne correspond pas entièrement au code du même SHA.
+
+Les absences ont été contrôlées dans les descripteurs, manifests, contextes, hooks, routes, migrations et tables, avec des recherches explicites sur les concepts « front release », « release manifest », « activation pointer », « renderer/action/data-source registry » et « Worker health/migration ». Les seuls « releases » natifs trouvés concernent les versions de paquets plugins, pas une version complète du front d’un site.
+
+## Vue synthétique
+
+| Domaine | Existe | Adaptable à la cible SuperBoard | Manque ou reste instable |
+| --- | --- | --- | --- |
+| Administration | SPA React à `/_emdash/admin`, écrans de contenu, médias, schémas, menus, widgets, taxonomies, réglages et plugins.[^admin-screens] | Pages/widgets/panneaux/colonnes React pour plugins natifs ; Block Kit pour plugins sandboxés.[^react-admin][^block-kit] | Aucune surface native pour composer le front produit public ; pages plugins confinées à leur namespace et incapables de remplacer les écrans core.[^admin-plugin-namespace] |
+| Schémas et collections | 16 types de champs, validations, références, repeater, index, supports drafts/révisions/preview/scheduling/search/SEO ; tables SQL `ec_*`.[^schema-types][^content-table] | Collections `json`/`portableText`/`reference`/`repeater` pour décrire une partie du modèle front. | Aucun schéma officiel page/layout/élément/action/data source/release, aucune validation inter-collections ou inter-plugins de la cible. |
+| Contenu et médias | Draft/live, révisions, programmation, traductions, médias locaux/R2/S3 et providers externes.[^content-publish][^media-library] | Contenu, textes, médias et certaines instances de composition peuvent alimenter un compilateur externe ou ajouté. | La révision est par entrée ; les menus/widgets/sections/options ne partagent pas ce workflow ; pas de cohérence globale de release. |
+| Authentification et RBAC | Passkeys, magic links, OAuth, providers, Cloudflare Access ; cinq rôles et une carte de permissions core.[^auth-guide][^rbac] | Providers et sessions peuvent servir de bridge d’identité ; les routes plugins peuvent exiger une permission core.[^plugin-route-auth] | Pas de page `/login` SuperBoard composée dans le CMS, pas de rôles/permissions front déclaratifs et extensibles, pas de guards ou politiques par route/élément/release. |
+| Plugins | Formats standard/sandboxé et natif, lifecycle, hooks, routes, KV, stockage, admin, blocs et MCP.[^plugin-descriptor][^plugin-manifest] | Les deux formats couvrent une grande partie des familles `supbrd-plug-*` et peuvent envelopper des appels externes. | Aucun registre public d’éléments/renderers/actions/data sources ; aucun descripteur de Worker métier, ressources, migration ou santé pour `supbrd-plugmod-*`. |
+| Sandbox | Runner Cloudflare Worker Loader et runner Node/workerd ; capabilities, isolation réseau, quotas.[^sandbox-security][^workerd-package] | Convient à du code backend déclaratif limité et à des UI Block Kit. | Dynamic Workers nécessite un compte Cloudflare payant ; capacités grossières ; pas de bindings hôte ; mémoire non plafonnée par plugin dans le runner Cloudflare ; sandbox Hyperdrive non supporté.[^paid-dynamic-workers][^cloudflare-runner-limits][^hyperdrive-sandbox-limit] |
+| Rendu du site | Site Astro SSR, Live Collections, Portable Text, menus et widgets récupérables à l’exécution.[^site-architecture][^menus][^widgets] | Un plugin natif peut fournir des composants Astro pour des blocs Portable Text ; un thème peut fournir des routes et layouts en code.[^portable-text-components][^themes] | Pas de thème/runtime abstrait, pas de routeur CMS générique, pas de renderer React public piloté par manifeste, pas de pages concrètes détenues par une release. |
+| Publication et versions | Publication atomique d’une entrée, révisions, preview signée, snapshots, sauvegardes, versions de plugin immuables.[^content-publish][^snapshot][^plugin-version-immutable] | Les mécanismes de snapshot, checksum de plugin et manifest de migrations donnent des motifs techniques réutilisables. | Pas de compilation globale, checksum de release site, activation atomique, rollback de release, promotion par environnement ou validation de parité. |
+| Migrations | Migrations core avec manifest de build exact et modes `auto`/`check`/`manual` ; évolution live du schéma via admin/API/CLI.[^core-migrations][^schema-evolution] | Manifest de migration, empreinte de cible, seed exporté et répétition CLI sont des primitives de contrôle. | Les changements de modèle de contenu prennent effet immédiatement, la suppression détruit la colonne et les données, et le stockage plugin n’a pas de migrations de données déclaratives.[^schema-evolution][^plugin-storage-migrations] |
+
+## 1. Administration
+
+### Existe
+
+L’administration est une SPA React servie sous `/_emdash/admin/*`. Elle expose nativement le dashboard, les listes et éditeurs de contenu, la médiathèque, le constructeur de schéma, les menus, zones de widgets, taxonomies, réglages et pages de plugins. Sa navigation est calculée depuis les collections et plugins installés.[^admin-screens]
+
+Le formulaire d’une collection est généré depuis ses champs. Les champs texte, nombres, booléens, dates, sélections, Portable Text, images et références ont des éditeurs intégrés. La médiathèque gère recherche, filtres, glisser-déposer, métadonnées et suppression en masse.[^admin-editor-media]
+
+### Adaptable
+
+Un plugin natif peut contribuer :
+
+- des pages React sous `/_emdash/admin/plugins/<plugin-id>/<path>` ;
+- des widgets de dashboard ;
+- des panneaux dans l’éditeur de contenu ;
+- des colonnes en lecture seule dans les listes de contenu ;
+- un formulaire de réglages auto-généré depuis `admin.settingsSchema`.[^react-admin]
+
+Un plugin sandboxé peut fournir une UI d’administration déclarative en JSON via Block Kit. Le host rend les blocs et renvoie les interactions au plugin, sans exécuter le JavaScript du plugin dans le navigateur.[^block-kit]
+
+Ces surfaces peuvent héberger les outils internes de définition, validation, preview et suivi d’une future Release Front.
+
+### Manque ou limite
+
+Ces extensions concernent **EmDash Admin**, pas le front public SuperBoard. Les pages plugins restent dans le namespace du plugin et un plugin ne peut pas remplacer un écran core de l’administration.[^admin-plugin-namespace] Aucun contrat audité ne permet à un plugin d’enregistrer une page publique SuperBoard, un layout public ou une route publique finale comme objet de premier rang.
+
+Les filtres `minRole` des panneaux et colonnes React ne sont que des filtres de visibilité ; la documentation exige de refaire l’autorisation dans les routes API. Ils ne forment pas une politique déclarative de front.[^react-visibility-not-auth]
+
+La désactivation d’un plugin natif masque ses liens, widgets, colonnes et pages d’administration, mais la documentation indique que ses hooks backend continuent à s’exécuter. Cette sémantique ne correspond pas automatiquement à « aucune contribution runtime d’un plugin désactivé » et devra être traitée explicitement dans le futur modèle front.[^plugin-disable-semantics]
+
+## 2. Schémas, collections et modèle de contenu
+
+### Existe
+
+Le registre de schéma stocké en base est la source de vérité. EmDash expose 16 types de champs : `string`, `text`, `url`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `portableText`, `image`, `file`, `reference`, `json`, `slug` et `repeater`. Les collections déclarent notamment les supports `drafts`, `revisions`, `preview`, `scheduling`, `search` et `seo`.[^schema-types]
+
+Chaque collection obtient une vraie table SQL `ec_<slug>` avec colonnes de cycle de vie, version optimiste, pointeurs de révision live/draft, locale et groupe de traduction, puis ses champs applicatifs comme colonnes typées.[^content-table]
+
+Une collection peut déclarer un `urlPattern`, être routable ou non, masquer son entrée de sidebar, choisir des colonnes d’administration et définir des champs de titre/date. Cela fournit des métadonnées utiles à une description de pages, mais pas une route exécutable à elle seule.[^collection-config]
+
+### Adaptable
+
+Les champs `json`, `portableText`, `reference` et `repeater` permettent de représenter des arbres de composition, des props, des références et du contenu éditorial. Les collections dédiées peuvent fournir des formulaires générés et un workflow draft/révision par enregistrement.
+
+Le modèle est exportable dans un seed avec réglages, collections, taxonomies, menus et zones de widgets, et l’option `--with-content` ajoute les entrées. Cette exportabilité est utile pour reproduire un environnement ou constituer une entrée de compilation.[^schema-evolution]
+
+### Manque ou limite
+
+Aucun type natif ne représente les concepts SuperBoard suivants : release front, page, layout, instance d’élément, renderer, action, data source, permission de front, route authentifiée, état loading/error/disabled/unavailable ou dépendance de Worker. Ces concepts ne figurent ni dans `PluginDescriptor` ni dans `PluginManifest`.[^plugin-descriptor][^plugin-manifest]
+
+EmDash valide chaque champ et chaque entrée, mais n’expose pas de validateur global pour :
+
+- l’unicité des routes après normalisation ;
+- l’unicité des identifiants d’éléments dans une page ;
+- la résolution de références entre pages, layouts, médias et plugins ;
+- les collisions de types d’éléments, actions ou data sources ;
+- les cycles de dépendances ;
+- la compatibilité entre version d’instance et version de renderer ;
+- la complétude des traductions d’une release.
+
+L’évolution du schéma live prend effet immédiatement. La documentation décrit une « migration » de modèle comme un script de commandes CLI exécutées environnement par environnement ; supprimer un champ supprime sa colonne et ses données.[^schema-evolution] Ce mécanisme ne fournit pas une version de schéma front préparée puis activée avec une release.
+
+## 3. Contenu, publication, révisions et traductions
+
+### Existe
+
+Les tables de contenu portent `status`, `version`, `live_revision_id` et `draft_revision_id`. La publication promeut la révision draft d’une entrée vers live, recopie les données de la révision dans la ligne et effectue une mise à jour atomique protégée par la version et les pointeurs attendus.[^content-publish-repository]
+
+Le handler officiel résume explicitement la portée : « one atomic content-row statement ». La transaction inclut éventuellement la création d’une redirection lorsque le slug change, mais toujours pour une seule entrée.[^content-publish]
+
+Le produit sait aussi dépublier, programmer une entrée, restaurer des révisions et publier les traductions indépendamment. Une restauration crée une nouvelle révision et conserve l’historique.[^working-content]
+
+### Adaptable
+
+Une future description de release pourrait utiliser des entrées draftées et révisées comme matière éditoriale. Le hook `content:afterSave` peut déclencher une invalidation ou une demande de compilation, et `content:afterPublish` signale une promotion d’entrée.[^content-hooks]
+
+### Manque ou limite
+
+Il n’existe pas de draft global regroupant plusieurs pages, menus, réglages et plugins. L’administration « bulk » n’ajoute pas cette garantie : elle appelle les endpoints existants par entrée, en parallèle limité, et accepte des succès partiels.[^bulk-publish]
+
+Les traductions ont chacune leur propre statut et historique et sont publiées indépendamment. EmDash ne garantit donc pas qu’un ensemble multilingue soit activé d’un seul geste.[^working-content]
+
+Le `PluginContext` accorde aux plugins `content:write` uniquement les opérations `create`, `update` et `delete` ; il n’expose pas `publish`, `schedule` ou une transaction multi-entrées.[^plugin-content-access] Le pilotage de ce workflow n’est donc pas réalisable avec ce contexte seul.
+
+## 4. Médias, menus, sections et widgets
+
+### Existe
+
+La médiathèque gère images, documents, vidéo et audio, dossiers, suivi d’usage, uploads et métadonnées. Les backends officiels couvrent le filesystem local, R2 et S3-compatible ; le flux d’upload utilise une cible signée quand l’adapter le permet et une route stream sinon.[^media-library]
+
+Les champs médias conservent un objet portable avec provider, id, URL éventuelle, dimensions, point focal, alt et métadonnées. EmDash fournit aussi des providers Cloudflare Images et Stream.[^media-values]
+
+Les menus sont des arbres ordonnés de liens, avec références vers contenus/taxonomies ou URL custom. Les zones de widgets acceptent du Portable Text, un menu ou un `componentId` et ses props. Les sections sont des fragments Portable Text réutilisables dans l’éditeur.[^menus][^widgets][^sections]
+
+### Adaptable
+
+Ces objets couvrent une part du besoin de navigation, textes et médias SuperBoard. Les `componentId` et `componentProps` des widgets ressemblent à une instance de renderer déclarative.
+
+### Manque ou limite
+
+Le mapping d’un `componentId` vers un composant reste écrit dans le template Astro. L’exemple officiel construit explicitement un `componentMap` dans `WidgetRenderer.astro` ; EmDash ne fournit pas un registre public dynamique de composants.[^widgets]
+
+Menus, widgets et sections sont des lignes actives, sans `live_revision_id`/`draft_revision_id` ni version de release. Les options globales n’ont qu’un nom et une valeur JSON.[^live-resource-tables] Une modification de ces ressources n’est donc pas automatiquement staged avec les entrées de pages.
+
+Le snapshot et la sauvegarde incluent les métadonnées média mais pas les binaires ; une release front autonome aurait donc besoin d’un contrat supplémentaire pour la référence et la disponibilité des médias.[^backup-contents]
+
+## 5. Authentification, sessions et RBAC
+
+### Existe
+
+EmDash fournit une authentification passkey/WebAuthn, des magic links, GitHub, Google et Atmosphere, ainsi qu’une interface de provider extensible. Cloudflare Access peut remplacer exclusivement les autres mécanismes.[^auth-guide]
+
+Les sessions utilisent des cookies HttpOnly, Secure, SameSite=Lax, avec expiration glissante de 30 jours par défaut.[^auth-sessions]
+
+Le RBAC comprend cinq niveaux fixes : Subscriber, Contributor, Author, Editor et Admin. La carte de permissions core couvre contenu, médias, taxonomies, commentaires, menus, bylines, widgets, sections, redirections, utilisateurs, réglages, schéma, plugins, import, backups, recherche et auth.[^rbac]
+
+Les routes privées de plugins sont authentifiées et exigent par défaut `plugins:manage`. Elles peuvent sélectionner une permission RBAC EmDash existante ; les routes publiques contournent auth, scopes et CSRF.[^plugin-route-auth]
+
+### Adaptable
+
+Un `AuthProviderDescriptor` peut fournir des composants React pour le login/setup de l’administration, des routes d’auth, des préfixes publics et son stockage. Cette interface, les sessions et l’identité de l’appelant transmise aux routes privées sont des primitives utilisables par un bridge d’identité.[^auth-provider][^plugin-route-user]
+
+### Manque ou limite
+
+Le login natif documenté est celui de `/_emdash/admin`. Aucun objet CMS ne décrit une page publique `/login`, son layout, ses textes, ses états ou l’URL de retour vers un shell SuperBoard.[^auth-guide]
+
+Les rôles et noms de permissions sont définis statiquement dans `@emdash-cms/auth`. Il n’existe pas de registre de permissions applicatives par plugin ou par release, ni de politique déclarative par page, élément, projet, cible ou environnement.[^rbac]
+
+Les routes plugins peuvent réutiliser les permissions core, mais leur contrat ne permet pas de déclarer de nouvelles permissions SuperBoard. Les contrôles de visibilité React `minRole` ne remplacent pas l’autorisation serveur.[^plugin-route-auth][^react-visibility-not-auth]
+
+## 6. Plugins : formats, lifecycle et distribution
+
+### Existe
+
+EmDash distingue :
+
+- le format standard, utilisable en processus ou en sandbox ;
+- le format natif, chargé au build, en processus, nécessaire pour React arbitraire dans l’admin, composants Astro publics de Portable Text et fragments HTML/scripts.[^plugin-descriptor][^plugin-formats]
+
+Le `PluginManifest` sérialise l’identité/version, le contrat d’accès, les capacités, hosts réseau, stockage, hooks, routes, MCP et contributions d’administration. Les hooks lifecycle couvrent installation, activation, désactivation et désinstallation.[^plugin-manifest][^lifecycle-hooks]
+
+Le marketplace/registre permet installation, consentement aux capacités, mise à jour et désinstallation de plugins sandboxés. Les versions publiées sont immuables et l’installation vérifie checksum, id, version et contrat de capacités.[^plugin-install][^registry-trust][^plugin-version-immutable]
+
+Ces capacités recouvrent une part importante de `supbrd-plug-*` : état et stockage propres, hooks, routes, UI de back-office et version du plugin.
+
+### Adaptable
+
+Une extension SuperBoard peut utiliser :
+
+- une page d’administration native ou Block Kit pour sa configuration ;
+- KV pour les petits réglages/états ;
+- stockage plugin pour des documents indexés ;
+- routes plugins pour ses endpoints JSON ;
+- hooks et cron pour le travail déclenché ou planifié ;
+- `ctx.http` pour appeler une API externe autorisée ;
+- le lifecycle pour initialiser ou préserver ses données.
+
+Une famille `supbrd-plugmod-*` peut donc être représentée partiellement par un plugin EmDash qui parle à un Worker existant. Cela ne signifie pas que le Worker est géré par EmDash : le contrat natif ne connaît pas son déploiement, ses bindings, ses migrations ou sa santé.
+
+### Manque ou limite
+
+`PluginDescriptor` est exhaustif : id, version, entrypoint, options, format, entrées admin/Astro, pages/widgets/settings/blocs/widgets de champs, capacités, hosts, stockage, MCP, routes et hooks. Il n’a aucun champ pour un Worker métier, une queue, un Durable Object, un Workflow, un Container, une liste de migrations, une sonde de santé ou une condition de readiness.[^plugin-descriptor]
+
+`PluginManifest` ne contient pas davantage ces concepts.[^plugin-manifest] EmDash ne peut donc pas nativement refuser une publication front parce que « le Worker, ses migrations ou sa santé ne sont pas prêts ».
+
+Les seules dépendances déclarées observées sont celles d’une configuration de hook, pour ordonner l’exécution de ce hook. Elles ne constituent pas un graphe de dépendances global entre plugin, renderer, layout, Worker et release.[^hook-config]
+
+## 7. Sandbox, capabilities et limites d’exécution
+
+### Existe
+
+Avec un runner actif, la sandbox applique :
+
+- gating de `ctx.content`, `ctx.taxonomies`, `ctx.media`, `ctx.http`, `ctx.users` et `ctx.email` ;
+- scoping du KV et du stockage par plugin ;
+- blocage du `fetch` direct, avec passage par la bridge et allowlist ;
+- absence de filesystem, variables d’environnement et bindings host ;
+- limites dépendant du runner.[^sandbox-security]
+
+Le runner Cloudflare utilise Dynamic Worker Loader et une bridge de service. Il bloque le réseau direct, configure 50 ms CPU, 10 subrequests et 30 secondes wall-clock par défaut. La valeur 128 MB est déclarée mais n’est pas configurable ni effectivement plafonnée par plugin par Worker Loader.[^sandbox-security][^cloudflare-runner-limits]
+
+Un paquet `@emdash-cms/sandbox-workerd` `0.5.1` existe pour Node et expose un runner workerd ; Miniflare est une dépendance optionnelle de développement.[^workerd-package]
+
+### Adaptable
+
+Les plugins sandboxés conviennent à des opérations backend limitées, au stockage scoped, aux hooks, aux routes JSON et aux UI Block Kit. Ils peuvent contribuer des métadonnées publiques structurées via `page:metadata`.[^page-hooks]
+
+### Manque ou limite
+
+Les capacités sont grossières : `content:write` autorise la modification de tout contenu, pas seulement celui créé par le plugin. Il n’existe pas de portée normative par collection, entrée, projet ou environnement.[^sandbox-coarse]
+
+Le type `DeclaredAccess` accepte des contraintes ouvertes, mais le code précise que les contraintes inconnues sont seulement consultatives ; la seule contrainte normativement appliquée aujourd’hui est `network.request.allowedHosts`.[^declared-access]
+
+Un plugin sandboxé ne voit aucun binding hôte. Il ne peut donc pas recevoir directement, par le contrat actuel, un service binding vers un Worker module, une Queue, un DO ou un Workflow.[^sandbox-security]
+
+Le README officiel avertit que Dynamic Workers n’est disponible que sur les comptes payants Cloudflare.[^paid-dynamic-workers] Le bridge des plugins sandboxés Cloudflare est en outre D1-only et n’est pas disponible avec Hyperdrive/PostgreSQL.[^hyperdrive-sandbox-limit] Un bundle publié au registre est plafonné à 256 Kio décompressés au total, 128 Kio par fichier et 20 fichiers ; il ne constitue donc pas un conteneur arbitrairement extensible.[^plugin-bundle-limits]
+
+Sans runner disponible, les plugins `sandboxed: []` sont ignorés au démarrage. Les déplacer dans `plugins: []` les exécute en processus sans frontière d’isolation et leur permet de contourner les capacités par les API du host.[^plugin-formats][^sandbox-coarse]
+
+## 8. Hooks
+
+### Existe
+
+Les hooks couvrent :
+
+- lifecycle plugin ;
+- sauvegarde, suppression, publication, dépublication, restauration et programmation d’une entrée ;
+- upload média ;
+- cron ;
+- email ;
+- commentaires ;
+- `page:metadata` et `page:fragments`.[^hook-names]
+
+Chaque hook peut définir priorité, timeout, dépendances d’ordre, politique `abort` ou `continue` et exclusivité pour quelques providers.[^hook-config]
+
+`page:metadata` renvoie des contributions structurées et validées pour meta, property, link allowlisté ou JSON-LD. `page:fragments`, réservé aux plugins natifs, peut injecter scripts ou HTML dans les emplacements auxquels le template public a explicitement souscrit.[^page-hooks]
+
+### Adaptable
+
+`content:afterSave`, `content:afterPublish` et `cron` sont des points possibles pour demander une revalidation ou une compilation. `plugin:activate` peut initialiser idempotemment de nouveaux réglages.[^content-hooks][^plugin-settings]
+
+### Manque ou limite
+
+La liste exhaustive n’inclut aucun hook pour :
+
+- modification de collection ou de champ ;
+- modification de menu, widget, zone, section ou réglage global ;
+- modification du contrat de permissions ;
+- changement de santé/migration d’un Worker ;
+- demande, succès, échec ou activation d’une Release Front.[^hook-names]
+
+Un compilateur qui doit observer **toutes** les surfaces du front ne peut donc pas se fier uniquement aux hooks actuels.
+
+## 9. Réglages, KV et stockage plugin
+
+### Existe
+
+Chaque plugin possède un KV privé `ctx.kv` avec `get`, `set`, `delete` et `list`. Les clés sont préfixées automatiquement par l’id du plugin dans la table d’options.[^plugin-settings]
+
+Les plugins sandboxés construisent leur écran de réglages en Block Kit et enregistrent les valeurs dans le KV. Les plugins natifs peuvent déclarer `admin.settingsSchema` pour obtenir un formulaire automatique.[^plugin-settings][^react-settings]
+
+Le stockage plugin fournit CRUD, batch, requêtes indexées, compteurs et pagination. Toutes les collections partagent `_plugin_storage`, avec scoping `plugin_id`/`collection` et données JSON ; les index déclarés sont créés comme index d’expression.[^plugin-storage]
+
+### Adaptable
+
+Le KV peut contenir de petits curseurs et réglages de compilation. Le stockage plugin peut contenir des documents de travail, diagnostics ou métadonnées de releases. Ces usages restent bornés par le contrat document-store et ne créent pas une release front nativement.
+
+### Manque ou limite
+
+Le stockage plugin n’a pas de workflow draft/live, de révisions, d’activation atomique ou de contrat d’immutabilité. Il n’a pas de migrations de données déclaratives : EmDash ajoute ou retire automatiquement les index, tandis qu’une migration de valeur doit être codée manuellement et idempotemment, par exemple dans `plugin:activate`.[^plugin-storage-migrations][^plugin-settings]
+
+Le `PluginContext` ne fournit aucune API de schéma, menus, widgets, sections ou réglages globaux. Sa liste exhaustive s’arrête au stockage/KV, contenu, taxonomies en lecture, médias, HTTP, log, site/URL, utilisateurs, cron et email.[^plugin-context] Un plugin sandboxé compilateur ne peut donc pas lire directement tout l’état nécessaire à une Release Front.
+
+## 10. Routes plugins, actions et data sources
+
+### Existe
+
+Les routes plugins sont montées sous `/_emdash/api/plugins/<slug>/<route-name>`, exécutées avec le même `PluginContext` que les hooks, et peuvent avoir un schéma Zod d’entrée. Les réponses JSON sont enveloppées dans le format EmDash.[^plugin-routes]
+
+Les routes privées disposent de l’utilisateur authentifié, peuvent choisir une permission core et sont protégées par CSRF pour les sessions cookie. Les routes publiques peuvent déclarer un `Cache-Control` pour les GET réussis.[^plugin-route-auth][^plugin-route-user]
+
+Une route privée peut être exposée explicitement comme outil MCP, avec schémas d’entrée/sortie, permission et marqueur destructif, après consentement administrateur.[^plugin-mcp]
+
+### Adaptable
+
+Les routes fournissent une primitive backend crédible pour implémenter des actions et data sources SuperBoard, y compris un proxy vers un Worker via `ctx.http`.
+
+### Manque ou limite
+
+Il n’existe pas de registre front typé d’actions/data sources, pas de liaison déclarative entre une instance d’élément et une route, pas de version de contrat intégrée à une release, et pas de validation globale de disponibilité. Les routes restent sous le namespace EmDash du plugin ; elles ne créent pas une route de page SuperBoard.
+
+Les routes publiques contournent entièrement l’auth et la CSRF, tandis que les routes privées utilisent le RBAC core. Le contrat ne fournit pas la notion intermédiaire « route publique du site mais nécessitant la session et une permission SuperBoard déclarée dans la release ».[^plugin-route-auth]
+
+## 11. Pages, layouts, renderers et rendu public
+
+### Existe
+
+EmDash est une intégration Astro. Le site écrit ses pages et composants, puis lit le contenu live via `getEmDashCollection()` et `getEmDashEntry()` ; l’administration et le contenu partagent la base.[^site-architecture]
+
+La documentation des thèmes est explicite : un thème EmDash est un projet Astro complet et « there is no theme API or abstraction layer ». Les routes, pages, layouts, composants et styles sont des fichiers du projet ; le seed initialise le modèle de contenu.[^themes]
+
+Les layouts sélectionnables par l’éditeur sont un champ `select` dont la valeur est mappée manuellement vers des imports Astro dans le fichier de route.[^page-layouts]
+
+Les plugins natifs peuvent fournir un `componentsEntry` qui exporte `blockComponents`. EmDash les fusionne dans le renderer `PortableText` ; cette surface concerne les types de blocs Portable Text et des composants Astro chargés au build.[^portable-text-components]
+
+Les plugins sandboxés peuvent déclarer les champs d’édition d’un bloc, mais ne peuvent pas livrer son renderer public. Le renderer doit venir d’un package natif ou du site.[^portable-text-components]
+
+### Adaptable
+
+Les blocs Portable Text, widgets à `componentId`, composants Astro natifs et champs JSON peuvent servir de précédents pour un futur registre SuperBoard. Block Kit peut être interprété par un renderer SuperBoard prévu dans du code de confiance.
+
+### Manque ou limite
+
+Ces surfaces ne constituent pas le renderer demandé :
+
+- aucun registre générique de primitives du front public ;
+- aucun renderer React public fourni par un plugin EmDash ;
+- aucun registre d’actions ou data sources ;
+- aucun routeur piloté par un manifeste CMS ;
+- aucune représentation native du login, du shell, des pages d’erreur/interdit/maintenance ou des états loading/disabled/unavailable ;
+- aucune séparation native « EmDash Admin interne / SuperBoard Admin public » au niveau d’un modèle de pages.
+
+L’`adminEntry` React s’exécute dans EmDash Admin, pas dans le site public.[^react-admin] Le `componentsEntry` public ne couvre que les blocs Portable Text Astro.[^portable-text-components] `page:fragments` injecte du HTML ou des scripts dans un template qui a ajouté les composants d’insertion ; il ne compose pas des pages.[^page-fragments]
+
+## 12. Preview, snapshots et sauvegardes
+
+### Existe
+
+La preview d’une entrée utilise un token HMAC signé et limité dans le temps. Le middleware sert implicitement le draft concerné au même template Astro.[^preview]
+
+Le endpoint `/_emdash/api/snapshot` produit un snapshot pour une base de preview isolée. Il inclut les tables de contenu dynamiques et les tables système nécessaires au rendu : schémas, taxonomies, menus, sections, zones/widgets, SEO, médias, options sûres et révisions.[^snapshot-route][^snapshot]
+
+Les sauvegardes enveloppent ce snapshot avec tous les contenus, y compris draft, scheduled et trash, et enregistrent la version EmDash. Elles excluent utilisateurs/auth, secrets, configuration plugin et binaires médias.[^backup-implementation][^backup-contents]
+
+### Adaptable
+
+Le snapshot constitue une source de données portable et déjà filtrée pour le rendu. Il peut aider à évaluer une preview ou constituer un input de compilation.
+
+### Manque ou limite
+
+Le snapshot n’est pas une Release Front :
+
+- il ne contient pas le stockage `_plugin_*` ni les réglages `plugin:*` ;
+- il exclut auth et secrets ;
+- il ne contient pas les binaires médias ;
+- son code parcourt successivement les tables et ajoute seulement `generatedAt`, sans id de release, checksum global, pointeur d’activation ou garantie explicite de lecture atomique sous écritures concurrentes.[^snapshot]
+
+La restauration du backup JSON n’est pas encore exposée ; un assistant CLI est seulement « planned ». Les options actuelles sont D1 Time Travel ou la réimportation d’un dump complet.[^backup-restore]
+
+La preview signée standard vise une entrée. Elle ne sélectionne pas un ensemble cohérent de drafts de pages, menus, réglages et plugins.
+
+## 13. Publication globale, immutabilité et rollback
+
+### Existe
+
+Trois primitives voisines existent, mais pour des objets différents :
+
+1. une entrée de contenu peut être promue atomiquement de draft vers live ;[^content-publish]
+2. une version publiée de plugin est immuable et vérifiée par checksum à l’installation ;[^registry-trust][^plugin-version-immutable]
+3. un build produit un manifest exact des migrations core, lié à l’artefact, et le CLI vérifie les migrations inconnues ou en attente.[^core-migrations]
+
+### Adaptable
+
+Ces mécanismes démontrent que le code possède déjà des briques pour versionner, vérifier une empreinte, contrôler une cible et refuser un état incompatible. Elles sont des précédents possibles pour le futur back du front.
+
+### Manque
+
+Aucune implémentation auditée ne fournit :
+
+- un `FrontRelease` immuable avec id, version, checksum, date, auteur et provenance ;
+- un bundle complet des routes, pages, layouts, éléments, textes, permissions, navigation et versions de plugins/renderers ;
+- un pipeline draft → normalisation → validations structurelles/inter-plugins → preview → publication ;
+- une activation par échange atomique d’un pointeur unique ;
+- une lecture du renderer limitée à la release active ;
+- un historique d’activations et un rollback vers une release précédente ;
+- une promotion du même artefact entre environnements ;
+- un état `failed` qui laisse l’ancienne release active ;
+- une politique de compatibilité entre release, `supbrd-core` et plugins.
+
+Ces capacités sont à développer ; elles ne doivent pas être confondues avec les révisions d’une entrée ou les versions des paquets plugins.
+
+## 14. Migrations
+
+### Existe : migrations core
+
+EmDash distingue les migrations core de l’évolution du modèle de contenu. Le build écrit `.emdash/migrations.json` avec version EmDash, liste ordonnée de migrations, locales et exécuteur de l’adapter. Le CLI offre `--status`, apply et `--check`, refuse les manifests/artefacts incompatibles et impose une empreinte de cible pour les applications non interactives.[^core-migrations]
+
+Le runtime propose `auto`, `check` et `manual`. La documentation décrit aussi la compatibilité expand/deploy/contract et la tolérance directionnelle des migrations inconnues pendant un rolling deploy.[^core-migrations]
+
+### Existe : modèle de contenu
+
+Le modèle live est modifié via admin ou CLI REST. Le seed ne s’applique qu’à une base vide ; changer le seed d’un déploiement existant ne modifie rien. Une migration répétable est documentée comme un script de commandes `emdash schema`.[^schema-evolution]
+
+### Limites pour la cible
+
+Le manifest de migrations core ne couvre ni les migrations des collections métier pilotées par un plugin, ni les migrations des Workers externes, ni la compatibilité d’une Release Front avec des renderers.
+
+Le stockage plugin n’a pas de migrations de données déclaratives. Les index sont convergés automatiquement ; l’auteur gère lui-même les changements de forme des documents.[^plugin-storage-migrations]
+
+Le futur contrôle « Worker + migrations + santé prêts avant activation » n’a aucun point de données standard dans `PluginDescriptor` ou `PluginManifest`.[^plugin-descriptor][^plugin-manifest]
+
+## 15. Instabilité et divergences observées
+
+### Statut général
+
+Le projet s’annonce lui-même en `beta preview`. Les paquets core sont `0.35.0` et le paquet de types partagé précise que le contrat de manifest peut évoluer avant la fin du RFC du registre.[^readme-status][^plugin-types-experimental]
+
+### Registre et contrat d’accès
+
+Le registre fédéré, ses lexicons et formes de records sont explicitement expérimentaux. La documentation conseille d’épingler la version exacte.[^registry-experimental]
+
+Le code accepte à la fois les capacités canoniques (`content:read`, `network:request`, etc.) et d’anciens alias (`read:content`, `network:fetch`, etc.) pendant une fenêtre de dépréciation. `declaredAccess` est encore optionnel dans le wire manifest pendant sa migration.[^capability-transition][^plugin-manifest]
+
+### Documentation et code de sandbox
+
+Au même SHA :
+
+- `@emdash-cms/sandbox-workerd` `0.5.1` est bien un package présent dans le monorepo et la page d’installation le documente ;[^workerd-package][^plugin-install]
+- la page de choix du format dit encore que le runner Node/workerd est « in development » ;[^plugin-formats]
+- plusieurs exemples de configuration utilisent `@emdash-cms/sandbox-cloudflare`, alors que le package présent est `@emdash-cms/cloudflare` et que sa fonction `sandbox()` renvoie `@emdash-cms/cloudflare/sandbox`.[^plugin-install][^cloudflare-sandbox-export]
+
+Ces divergences n’annulent pas les capacités du code, mais elles prouvent que cette surface évolue rapidement et que les exemples doivent être vérifiés contre le package épinglé.
+
+### Limitations documentées dans le code Cloudflare
+
+Le support de sandbox avec Hyperdrive/PostgreSQL est explicitement absent parce que la bridge parle directement à D1.[^hyperdrive-sandbox-limit] La limite mémoire par plugin du runner Cloudflare est déclarative mais non appliquée par Worker Loader.[^cloudflare-runner-limits]
+
+## 16. Points d’extension disponibles pour une future Release Front
+
+Cette section inventorie des coutures techniques ; elle ne choisit pas l’architecture.
+
+1. **Modèle éditorial** — collections dynamiques avec JSON, Portable Text, références, repeater, drafts et révisions par entrée.[^schema-types][^content-table]
+2. **Back-office spécialisé** — pages React natives, panneaux d’éditeur, colonnes de listes, settings auto-générés ou pages Block Kit.[^react-admin][^block-kit]
+3. **Backend de compilation** — route plugin privée, hooks de contenu et cron ; contraintes : namespace plugin, RBAC core et contexte incomplet pour les ressources globales.[^plugin-routes][^plugin-context][^hook-names]
+4. **État de travail** — KV et stockage document indexé par plugin ; contraintes : pas de draft/live, version immuable ni migration déclarative.[^plugin-settings][^plugin-storage]
+5. **Matière de snapshot** — endpoint snapshot comprenant contenu et chrome du site ; contraintes : exclusions plugin/auth/médias et absence de contrat de release atomique.[^snapshot]
+6. **Renderers build-time** — `componentsEntry` et composants Astro de blocs Portable Text ; contraintes : pas de registre générique public React ni de chargement sandboxé de renderer.[^portable-text-components]
+7. **Appels métier** — routes plugins et `ctx.http` avec allowlist ; contraintes : pas de service binding sandboxé ni descripteur de Worker/readiness.[^plugin-routes][^sandbox-security][^plugin-descriptor]
+8. **Vérification d’artefacts** — checksum et immutabilité de versions plugins, ainsi que manifest exact de migrations core ; contraintes : ces contrats ne s’appliquent pas encore au front du site.[^registry-trust][^plugin-version-immutable][^core-migrations]
+9. **Identité** — providers, sessions et utilisateur authentifié des routes privées ; contraintes : page publique et permissions SuperBoard absentes.[^auth-provider][^plugin-route-user][^rbac]
+
+## 17. Écart précis avec les exigences SuperBoard
+
+| Exigence SuperBoard | État EmDash audité | Qualification |
+| --- | --- | --- |
+| EmDash Admin interne à `/_emdash/admin` | Fourni nativement. | **Existe** |
+| Front SuperBoard distinct après `/login` | Astro permet d’écrire ces routes, mais EmDash ne les modélise ni ne les compose. | **À développer** |
+| Toutes les pages/layouts/routes/textes/états détenus par EmDash | Contenus, menus, widgets et médias existent ; routes/layouts/renderers restent du code Astro. | **Partiel, à adapter puis développer** |
+| `supbrd-core` sans page concrète, renderer générique | Aucun contrat équivalent. | **À développer** |
+| Registre typé éléments/renderers | PT blocks et component widgets sont des précédents limités. | **À développer** |
+| Registre actions/data sources | Routes plugins et MCP sont des précédents backend. | **À développer** |
+| `supbrd-plug-*` sans Worker | Plugins EmDash couvrent backend, storage, settings et admin. La contribution au front public manque. | **Fortement adaptable** |
+| `supbrd-plugmod-*` avec Worker | Appel HTTP possible ; aucun descripteur, binding, migration, santé ou readiness standard. | **Partiel, contrat à développer** |
+| Plugins sandboxés contribuant du Block Kit au front | Block Kit existe uniquement comme renderer d’admin/plugin et champs d’édition de blocs ; pas de renderer public SuperBoard officiel. | **À adapter** |
+| Validation structurelle et inter-plugins | Validations locales de champ, manifest, capacité et route existent. Pas de compilateur global. | **À développer** |
+| Détection route/id/type/action/data source en double | Aucune surface globale correspondante. | **À développer** |
+| Détection références, permissions, traductions, cycles | Quelques validations locales existent ; aucune validation de graphe de release. | **À développer** |
+| Vérification Worker/migrations/santé | Absente des manifests/descripteurs. | **À développer** |
+| Preview complète d’un draft de front | Preview par entrée et snapshot de preview existent, sans sélection cohérente de release. | **À adapter** |
+| Release complète immuable + checksum | Immutabilité/checksum existent pour les paquets plugins seulement. | **À développer** |
+| Activation atomique | Publication atomique par entrée seulement. | **À développer** |
+| Renderer ne lisant jamais les drafts | Les queries publiques servent le live ; aucune API de « release active » globale n’existe. | **À développer** |
+| Rollback de release | Révisions d’entrée et D1 Time Travel existent ; restore JSON prévu, pas de rollback front. | **À développer** |
+| Permissions déclarées dans la release | RBAC core statique uniquement. | **À développer** |
+| Compatibilité stricte et aucune perte de données | Migrations core prudentes ; évolution de schéma peut supprimer irréversiblement des colonnes. | **Contrôle supplémentaire requis** |
+
+## Conclusion factuelle
+
+EmDash peut accueillir le **plan de contrôle éditorial** de SuperBoard et une grande partie de l’enveloppe backend de plugins. Il possède déjà les primitives de schéma, contenu, médias, auth, admin, lifecycle, storage, hooks et API qui évitent de reconstruire un CMS.
+
+En revanche, la propriété « tout le front SuperBoard est géré et publié depuis EmDash » n’est pas une fonctionnalité existante d’EmDash `0.35.0`. Le site public reste un projet Astro dont routes, layouts et composants sont livrés en code. Les mécanismes de publication sont locaux à une entrée ou à un paquet plugin, pas à un graphe complet de front.
+
+Le travail à développer se concentre donc, factuellement, sur un nouveau domaine de Release Front : contrats de déclaration, registre de primitives, compilation et validations globales, artefact immuable, activation/rollback atomiques, permissions applicatives, intégration des Workers et renderer public. Cet audit ne décide ni où stocker ce domaine, ni quel format de plugin employer, ni comment l’exécuter.
+
+## Sources primaires épinglées
+
+[^pkg-core]: [`packages/core/package.json`, lignes 1–5](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/package.json#L1-L5)
+[^pkg-admin]: [`packages/admin/package.json`, lignes 1–5](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/admin/package.json#L1-L5)
+[^pkg-cloudflare]: [`packages/cloudflare/package.json`, lignes 1–5](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/cloudflare/package.json#L1-L5)
+[^readme-features]: [`README.md`, lignes 104–156](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/README.md#L104-L156)
+[^readme-status]: [`README.md`, lignes 135–166](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/README.md#L135-L166)
+[^paid-dynamic-workers]: [`README.md`, lignes 1–18](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/README.md#L1-L18)
+[^site-architecture]: [`docs/src/content/docs/concepts/architecture.mdx`, lignes 8–98](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/concepts/architecture.mdx#L8-L98)
+[^admin-screens]: [`docs/src/content/docs/concepts/admin-panel.mdx`, lignes 8–36](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/concepts/admin-panel.mdx#L8-L36)
+[^admin-editor-media]: [`docs/src/content/docs/concepts/admin-panel.mdx`, lignes 39–75](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/concepts/admin-panel.mdx#L39-L75)
+[^admin-plugin-namespace]: [`docs/src/content/docs/concepts/admin-panel.mdx`, lignes 72–75](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/concepts/admin-panel.mdx#L72-L75)
+[^schema-types]: [`packages/core/src/schema/types.ts`, lignes 1–105 et 117–173](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/schema/types.ts#L1-L173)
+[^collection-config]: [`packages/core/src/schema/types.ts`, lignes 175–229](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/schema/types.ts#L175-L229)
+[^content-table]: [`packages/core/src/schema/registry.ts`, lignes 1409–1456](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/schema/registry.ts#L1409-L1456)
+[^schema-evolution]: [`docs/src/content/docs/deployment/schema-evolution.mdx`, lignes 8–86 et 124–128](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/deployment/schema-evolution.mdx#L8-L128)
+[^working-content]: [`docs/src/content/docs/guides/working-with-content.mdx`, lignes 157–234 et 306–334](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/working-with-content.mdx#L157-L334)
+[^content-publish]: [`packages/core/src/api/handlers/content.ts`, lignes 1573–1625](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/api/handlers/content.ts#L1573-L1625)
+[^content-publish-repository]: [`packages/core/src/database/repositories/content.ts`, lignes 1752–1969](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/database/repositories/content.ts#L1752-L1969)
+[^bulk-publish]: [`packages/admin/src/lib/bulk.ts`, lignes 1–40](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/admin/src/lib/bulk.ts#L1-L40)
+[^media-library]: [`docs/src/content/docs/guides/media-library.mdx`, lignes 9–177 et 296–314](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/media-library.mdx#L9-L314)
+[^media-values]: [`docs/src/content/docs/guides/media-library.mdx`, lignes 448–523](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/media-library.mdx#L448-L523)
+[^menus]: [`docs/src/content/docs/guides/menus.mdx`, lignes 8–65 et 118–202](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/menus.mdx#L8-L202)
+[^widgets]: [`docs/src/content/docs/guides/widgets.mdx`, lignes 8–178](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/widgets.mdx#L8-L178)
+[^sections]: [`docs/src/content/docs/guides/sections.mdx`, lignes 8–92 et 158–209](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/sections.mdx#L8-L209)
+[^live-resource-tables]: [`packages/core/src/database/types.ts`, lignes 396–415 et 478–628](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/database/types.ts#L396-L628)
+[^auth-guide]: [`docs/src/content/docs/guides/authentication.mdx`, lignes 8–16, 92–118 et 208–224](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/authentication.mdx#L8-L224)
+[^auth-provider]: [`docs/src/content/docs/guides/authentication.mdx`, lignes 182–206](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/authentication.mdx#L182-L206)
+[^auth-sessions]: [`docs/src/content/docs/guides/authentication.mdx`, lignes 267–276](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/authentication.mdx#L267-L276)
+[^rbac]: [`packages/auth/src/rbac.ts`, lignes 8–112 et 177–232](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/auth/src/rbac.ts#L8-L232)
+[^plugin-overview]: [`docs/src/content/docs/plugins/overview.mdx`, lignes 8–40](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/overview.mdx#L8-L40)
+[^plugin-formats]: [`docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx`, lignes 8–74](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx#L8-L74)
+[^plugin-descriptor]: [`packages/core/src/astro/integration/runtime.ts`, lignes 50–154](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/astro/integration/runtime.ts#L50-L154)
+[^plugin-manifest]: [`packages/plugin-types/src/index.ts`, lignes 291–434](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/plugin-types/src/index.ts#L291-L434)
+[^plugin-types-experimental]: [`packages/plugin-types/src/index.ts`, lignes 1–31](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/plugin-types/src/index.ts#L1-L31)
+[^capability-transition]: [`packages/plugin-types/src/index.ts`, lignes 33–160 et 404–420](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/plugin-types/src/index.ts#L33-L160)
+[^declared-access]: [`packages/plugin-types/src/index.ts`, lignes 163–192](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/plugin-types/src/index.ts#L163-L192)
+[^sandbox-security]: [`docs/src/content/docs/plugins/creating-plugins/capabilities.mdx`, lignes 82–106](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx#L82-L106)
+[^sandbox-coarse]: [`docs/src/content/docs/plugins/creating-plugins/capabilities.mdx`, lignes 100–120](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx#L100-L120)
+[^cloudflare-runner-limits]: [`packages/cloudflare/src/sandbox/runner.ts`, lignes 34–48](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/cloudflare/src/sandbox/runner.ts#L34-L48)
+[^hyperdrive-sandbox-limit]: [`packages/cloudflare/src/index.ts`, lignes 356–365](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/cloudflare/src/index.ts#L356-L365)
+[^workerd-package]: [`packages/workerd/package.json`, lignes 1–37](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/workerd/package.json#L1-L37)
+[^cloudflare-sandbox-export]: [`packages/cloudflare/src/index.ts`, lignes 529–542](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/cloudflare/src/index.ts#L529-L542)
+[^hook-names]: [`packages/plugin-types/src/manifest-schema.ts`, lignes 87–124](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/plugin-types/src/manifest-schema.ts#L87-L124)
+[^hook-config]: [`docs/src/content/docs/plugins/creating-plugins/hooks.mdx`, lignes 25–69 et 326–384](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/hooks.mdx#L25-L69)
+[^lifecycle-hooks]: [`docs/src/content/docs/plugins/creating-plugins/hooks.mdx`, lignes 71–131](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/hooks.mdx#L71-L131)
+[^content-hooks]: [`docs/src/content/docs/plugins/creating-plugins/hooks.mdx`, lignes 133–235](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/hooks.mdx#L133-L235)
+[^page-hooks]: [`docs/src/content/docs/plugins/creating-plugins/hooks.mdx`, lignes 262–325](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/hooks.mdx#L262-L325)
+[^plugin-context]: [`docs/src/content/docs/plugins/creating-plugins/api-routes.mdx`, lignes 529–569](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx#L529-L569)
+[^plugin-content-access]: [`packages/core/src/plugins/types.ts`, lignes 311–356](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/plugins/types.ts#L311-L356)
+[^plugin-routes]: [`docs/src/content/docs/plugins/creating-plugins/api-routes.mdx`, lignes 8–55 et 84–97](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx#L8-L97)
+[^plugin-route-auth]: [`docs/src/content/docs/plugins/creating-plugins/api-routes.mdx`, lignes 99–134 et 159–173](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx#L99-L173)
+[^plugin-route-user]: [`docs/src/content/docs/plugins/creating-plugins/api-routes.mdx`, lignes 136–157](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx#L136-L157)
+[^plugin-mcp]: [`docs/src/content/docs/plugins/creating-plugins/api-routes.mdx`, lignes 175–211](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx#L175-L211)
+[^plugin-settings]: [`docs/src/content/docs/plugins/creating-plugins/settings.mdx`, lignes 8–25, 66–162 et 190–230](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/settings.mdx#L8-L230)
+[^react-settings]: [`docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx`, lignes 398–411](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx#L398-L411)
+[^plugin-storage]: [`docs/src/content/docs/plugins/creating-plugins/storage.mdx`, lignes 8–92 et 279–315](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/storage.mdx#L8-L315)
+[^plugin-storage-migrations]: [`docs/src/content/docs/plugins/creating-plugins/storage.mdx`, lignes 296–320](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/storage.mdx#L296-L320)
+[^block-kit]: [`docs/src/content/docs/plugins/creating-plugins/block-kit.mdx`, lignes 8–25 et 77–105](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx#L8-L105)
+[^react-admin]: [`docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx`, lignes 8–64, 168–225 et 227–333](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx#L8-L333)
+[^react-visibility-not-auth]: [`docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx`, lignes 256–261 et 325–333](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx#L256-L333)
+[^plugin-disable-semantics]: [`docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx`, lignes 459–473](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx#L459-L473)
+[^portable-text-components]: [`docs/src/content/docs/plugins/creating-native-plugins/portable-text-components.mdx`, lignes 8–70 et 92–100](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/portable-text-components.mdx#L8-L100)
+[^page-fragments]: [`docs/src/content/docs/plugins/creating-native-plugins/page-fragments.mdx`, lignes 8–35 et 37–68](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-native-plugins/page-fragments.mdx#L8-L68)
+[^themes]: [`docs/src/content/docs/themes/creating-themes.mdx`, lignes 8–48 et 158–166](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/themes/creating-themes.mdx#L8-L166)
+[^page-layouts]: [`docs/src/content/docs/guides/page-layouts.mdx`, lignes 8–16 et 96–144](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/page-layouts.mdx#L8-L144)
+[^preview]: [`docs/src/content/docs/guides/preview.mdx`, lignes 8–37 et 39–71](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/preview.mdx#L8-L71)
+[^snapshot-route]: [`packages/core/src/astro/routes/api/snapshot.ts`, lignes 1–8 et 93–103](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/astro/routes/api/snapshot.ts#L1-L103)
+[^snapshot]: [`packages/core/src/api/handlers/snapshot.ts`, lignes 141–208 et 220–367](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/api/handlers/snapshot.ts#L141-L367)
+[^backup-implementation]: [`packages/core/src/api/handlers/backup.ts`, lignes 1–18 et 106–130](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/packages/core/src/api/handlers/backup.ts#L1-L130)
+[^backup-contents]: [`docs/src/content/docs/guides/backups.mdx`, lignes 8–27](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/backups.mdx#L8-L27)
+[^backup-restore]: [`docs/src/content/docs/guides/backups.mdx`, lignes 65–103](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/guides/backups.mdx#L65-L103)
+[^core-migrations]: [`docs/src/content/docs/deployment/core-migrations.mdx`, lignes 8–48 et 167–193](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/deployment/core-migrations.mdx#L8-L193)
+[^plugin-install]: [`docs/src/content/docs/plugins/installing.mdx`, lignes 8–72 et 100–166](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/installing.mdx#L8-L166)
+[^registry-experimental]: [`docs/src/content/docs/plugins/registry.mdx`, lignes 8–18](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/registry.mdx#L8-L18)
+[^registry-trust]: [`docs/src/content/docs/plugins/registry.mdx`, lignes 81–104](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/registry.mdx#L81-L104)
+[^plugin-version-immutable]: [`docs/src/content/docs/plugins/creating-plugins/publishing.mdx`, lignes 121–136](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/publishing.mdx#L121-L136)
+[^plugin-bundle-limits]: [`docs/src/content/docs/plugins/creating-plugins/publishing.mdx`, lignes 80–98](https://github.com/emdash-cms/emdash/blob/1717d31b351164a5f78e95fe004ee582c7c50f40/docs/src/content/docs/plugins/creating-plugins/publishing.mdx#L80-L98)

--- a/docs/EMDASH_CLOUDFLARE_FIT_2026-08-29.md
+++ b/docs/EMDASH_CLOUDFLARE_FIT_2026-08-29.md
@@ -1,0 +1,300 @@
+# Compatibilité d’EmDash avec la topologie Cloudflare de SuperBoard
+
+> Recherche liée au ticket [Vérifier la compatibilité d’EmDash avec la topologie Cloudflare SuperBoard](https://github.com/mabzadev/superboard/issues/42), enfant de la carte [Migration complète de SuperBoard vers EmDash CMS](https://github.com/mabzadev/superboard/issues/33).
+>
+> État observé le 29 août 2026. Cette note établit des faits, incompatibilités et prérequis. Elle ne choisit pas l’architecture cible et n’implémente rien.
+
+## Réponse courte
+
+Cloudflare Workers peut techniquement exécuter un Site EmDash à côté des Workers métier de SuperBoard. La release EmDash 0.35.0 se construit avec Astro 7 et passe un dry-run Wrangler comme Worker Cloudflare lié à D1, R2, KV Sessions, Assets, AI Search et Dynamic Worker Loader. Le paquet mesuré reste sous la limite du plan Workers Paid.
+
+En revanche, EmDash n’est pas compatible avec le Dashboard ou le control plane SuperBoard actuels sans changement :
+
+- EmDash est une intégration Astro SSR ; le Dashboard actuel est une application Next.js produisant un Worker OpenNext.
+- Le Worker Dashboard actuel ne possède aucun binding D1 EmDash, R2 MEDIA, KV SESSION, Worker Loader ni Cron EmDash.
+- Les manifests de cibles, le registre des services, le registre des propriétaires D1, les secrets, le déploiement et les contrôles de santé de SuperBoard ne connaissent aucun service CMS.
+- Le mécanisme obligatoire de sauvegarde de production SuperBoard repose sur wrangler d1 export. Cloudflare ne sait pas exporter une base contenant des tables virtuelles, alors qu’EmDash crée des tables FTS5 virtuelles lorsque la recherche d’une collection est activée.
+- Le flag global_fetch_strictly_public est actuellement appliqué à tous les Workers SuperBoard. EmDash documente que ce flag bloque le transport interne des D1 Sessions et fait pendre les requêtes lorsque la réplication de lecture est activée.
+- Cloudflare limite à quatre le nombre de Dynamic Workers distincts simultanément actifs dans une requête Worker. EmDash 0.35.0 lance en parallèle tous les hooks différés des plugins sandboxés, sans borne à quatre.
+- Le Tail Worker SuperBoard peut observer le Worker hôte EmDash, mais le runner EmDash n’attache pas de tail aux Dynamic Workers. Les appels ctx.log repassent par le bridge hôte ; les console.log, exceptions et métadonnées propres à l’isolate dynamique ne sont pas automatiquement collectés.
+
+La conclusion factuelle est donc : **compatibilité de plateforme conditionnelle, incompatibilité de contrôle et d’exploitation en l’état**. Aucun basculement, même en développement, n’est prêt avant la levée des prérequis listés dans cette note.
+
+## Références immuables examinées
+
+| Élément | Référence épinglée | Observation |
+| --- | --- | --- |
+| SuperBoard | commit [d1850233e97b79c3cde7eae18a0123d4d39c8ae2](https://github.com/mabzadev/superboard/commit/d1850233e97b79c3cde7eae18a0123d4d39c8ae2) | Point de départ imposé à cette recherche. |
+| EmDash publié | tag emdash@0.35.0, commit [3c99225d80a38a9751ed0e4b56e3924e40308e70](https://github.com/emdash-cms/emdash/commit/3c99225d80a38a9751ed0e4b56e3924e40308e70) | Dernière release trouvée dans le clone complet ; base reproductible utilisée pour les mesures de paquet. |
+| EmDash main | commit [1717d31b351164a5f78e95fe004ee582c7c50f40](https://github.com/emdash-cms/emdash/commit/1717d31b351164a5f78e95fe004ee582c7c50f40) | État du dépôt le 28 août 2026, soixante commits après 0.35.0. Utilisé uniquement pour vérifier les évolutions déjà présentes en amont. |
+
+Le dépôt EmDash a été cloné sans shallow clone et avec récursion des submodules. Aucun submodule n’était déclaré. Le dépôt se décrit lui-même comme une beta preview ; une migration ne doit donc pas confondre la branche main, qui affiche toujours 0.35.0 dans ses manifests, avec l’artefact immuable de la release 0.35.0. Sources : [README EmDash 0.35.0](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/README.md), [package core 0.35.0](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/core/package.json), [package Cloudflare 0.35.0](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/package.json).
+
+La release fixe le socle de démonstration Cloudflare à Astro 7.0.0, @astrojs/cloudflare 14.0.0, React 19.2.4, Wrangler 4.124.0, pnpm 11.9.0 et Node 22.16 au minimum. SuperBoard utilise npm, Next 16.3, React 18.3 et Wrangler 4.120.0 dans son Dashboard, tandis que ses workflows sélectionnent Node 22. Il n’y a pas d’incompatibilité de version Node démontrée, mais il existe deux graphes de build et deux versions de Wrangler à unifier ou à isoler explicitement. Sources : [workspace EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/pnpm-workspace.yaml), [package du Dashboard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/package.json), [workflow Cloudflare](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/.github/workflows/deploy-cloudflare.yml).
+
+## Topologie SuperBoard constatée
+
+SuperBoard est un monorepo canonique pilotant plusieurs cibles Cloudflare depuis des manifests déclaratifs. Le développement mbza-development et la production vocostar peuvent vivre dans des comptes Cloudflare différents ; chaque compte est sélectionné à l’exécution et les identifiants de compte ne sont pas committés. Sources : [README SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/README.md), [cible mbza-development](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/mbza-development.json), [cible vocostar](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/vocostar.json).
+
+Les manifests nomment dix-sept Workers de plateforme ou de domaine par cible ; VocoStar déclare en plus deux Workers managés d’orchestration. Certaines fonctionnalités sont désactivées selon la cible, de sorte que ce nombre est un plafond déclaratif et non le nombre exact d’instances actives. Cette topologie est très en dessous de la limite actuelle de 500 Workers par compte Paid. Les Dynamic Workers chargés par EmDash ne sont pas des scripts statiques supplémentaires de ce catalogue, mais ils ont leur propre facturation et leur propre limite de concurrence. Sources : [registre de services SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-services.mjs), [limites Workers](https://developers.cloudflare.com/workers/platform/limits/), [tarification Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/pricing/).
+
+Le générateur de configuration SuperBoard applique actuellement à chaque service :
+
+- la date de compatibilité 2026-08-08 ;
+- nodejs_compat et global_fetch_strictly_public ;
+- workers.dev et les preview URLs désactivés ;
+- Workers Logs à 100 %, traces à 10 % ;
+- un Tail Worker observability pour tous les services sauf le Tail Worker lui-même.
+
+Le Dashboard est ensuite une exception de build : le point d’entrée est apps/dashboard/.open-next/worker.js, les assets viennent de .open-next/assets, le cache incrémental Next est un bucket R2 NEXT_INC_CACHE_R2_BUCKET, et le Worker possède un service binding vers lui-même. Il ne possède ni D1, ni R2 MEDIA, ni KV SESSION, ni Worker Loader, ni Cron. Source : [générateur Cloudflare SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-config.mjs).
+
+Les domaines du Dashboard sont des Custom Domains exacts : board.mbza.dev en développement et grow.vocostar.com en production. Les autres Workers communiquent largement par Service bindings et possèdent chacun leurs ressources D1, R2, KV, Queues, Durable Objects, Workflows ou Analytics Engine selon leur rôle. Les migrations D1 sont attribuées à un seul propriétaire de schéma et sont des fichiers SQL ordonnés. Sources : [cible mbza-development](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/mbza-development.json), [cible vocostar](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/vocostar.json), [registre D1](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-registry.mjs).
+
+## Forme Cloudflare d’EmDash constatée
+
+EmDash n’est pas une bibliothèque CMS agnostique du framework à injecter dans Next.js. C’est une intégration Astro qui ajoute au Site Astro l’administration, les routes API, l’authentification, les migrations et le runtime de plugins. Le démonstrateur Cloudflare est en output server et utilise l’adapter Cloudflare. Sources : [README EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/README.md), [configuration Astro du démonstrateur](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/astro.config.mjs).
+
+Le Worker officiel lie :
+
+| Binding ou capacité | Rôle observé | Caractère |
+| --- | --- | --- |
+| D1 DB | Tables internes, collections, utilisateurs, plugins et contenu | Requis par la configuration Cloudflare examinée |
+| R2 MEDIA | Binaire des médias | Requis par la configuration examinée |
+| KV SESSION | Sessions Astro | Ajouté automatiquement par l’adapter Cloudflare |
+| Assets | Assets Astro compilés | Ajouté par l’adapter |
+| Worker Loader LOADER | Dynamic Workers des plugins sandboxés | Requis si les plugins sandboxés sont utilisés |
+| PluginBridge exporté | RPC contrôlé entre isolates et Worker hôte | Requis avec LOADER |
+| Cron | Publication planifiée, tâches plugins et maintenance | Un cron général sur main ; deux crons dans la release 0.35.0 du démonstrateur |
+| Observability | Logs du Worker hôte | Activé dans le démonstrateur |
+| KV CACHE | Cache objet D1 | Optionnel et distinct de SESSION |
+| AI_SEARCH et Images | Recherche IA et transformations média | Options du démonstrateur, pas minimum universel du CMS |
+
+Sources : [Wrangler EmDash 0.35.0](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/wrangler.jsonc), [entrypoint Worker](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/src/worker.ts), [déploiement Cloudflare EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/docs/src/content/docs/deployment/cloudflare.mdx), [adapter Astro Cloudflare](https://docs.astro.build/en/guides/integrations-guide/cloudflare/).
+
+Le bucket NEXT_INC_CACHE_R2_BUCKET du Dashboard OpenNext ne remplit donc pas le rôle de MEDIA. De même, le KV général du Worker API SuperBoard n’est pas automatiquement le KV SESSION du Site Astro. Accepter l’auto-provisionnement de SESSION par Wrangler contournerait le manifeste de cible et ses identités immuables ; le resource binding doit être explicitement modélisé ou son auto-provisionnement explicitement enregistré par le control plane. Cloudflare prend désormais en charge l’auto-provisionnement de D1, R2 et KV lorsqu’un binding n’a pas d’identifiant, mais cela ne remplace pas les règles de gouvernance propres à SuperBoard. Sources : [provisionnement automatique Cloudflare](https://developers.cloudflare.com/changelog/post/2025-10-24-automatic-resource-provisioning/), [adapter Astro Cloudflare](https://docs.astro.build/en/guides/integrations-guide/cloudflare/), [frontières de configuration SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/CONFIGURATION_BOUNDARIES.md).
+
+## Matrice de compatibilité
+
+| Sujet | Fait vérifié | État |
+| --- | --- | --- |
+| Runtime SSR | Astro Cloudflare produit un Worker ES modules valide ; le dry-run de la release passe. | Compatible |
+| Dashboard actuel | Le build et l’entrypoint sont Next/OpenNext, pas Astro. | Incompatible sans remplacement ou surface distincte |
+| D1 | EmDash fournit un adapter D1 et un workflow de migrations. | Compatible sous nouvelles ressources et nouveau control plane |
+| R2 | EmDash fournit un adapter R2 natif. | Compatible ; ressource et politique média à déclarer |
+| KV | Astro utilise KV pour SESSION ; EmDash peut utiliser un second KV pour CACHE. | Compatible ; identités absentes aujourd’hui |
+| Plugins sandboxés | Worker Loader et bridge fonctionnent dans le modèle Cloudflare. | Compatible sous Workers Paid, avec limites de concurrence et observabilité à traiter |
+| Workers for Platforms | Le code officiel utilise worker_loaders, pas dispatch_namespaces. | Non requis par la forme EmDash examinée |
+| Service bindings | Un Site Astro Worker peut recevoir des bindings vers les Workers SuperBoard du même compte. | Compatible sous même compte et contrats explicites |
+| Appels depuis plugin sandboxé | ctx.http utilise globalThis.fetch vers des hôtes HTTP autorisés, pas un binding SuperBoard privé. | Lacune fonctionnelle pour tout contrat privé attendu |
+| Routage | Custom Domains, Routes et versions permettent une coexistence orchestrée. | Compatible, mais aucun plan de propriété de route n’existe |
+| Local | D1, R2, KV et Service bindings ont des simulations locales ; la preuve complète LOADER du démo n’est pas locale et autonome. | Partiellement prouvé |
+| Migrations | EmDash peut générer un manifest, appliquer et vérifier avant trafic. | Compatible en principe, non intégré au registre SQL SuperBoard |
+| Sauvegarde | L’export obligatoire SuperBoard échoue sur les bases avec FTS5 virtuel. | Bloquant |
+| D1 read replicas | EmDash les prend en charge avec Sessions. | Bloqué par le flag SuperBoard si le mode session est activé |
+| Observabilité hôte | Workers Logs, traces et Tail Worker sont disponibles. | Compatible |
+| Observabilité isolates | Aucun tail attaché par le runner EmDash 0.35.0. | Incomplète |
+| Déploiement multi-cible | Astro 6+ exige un build par environnement ; SuperBoard construit déjà le Dashboard par cible. | Compatible après remplacement du build |
+| Rollback | Les versions Worker se restaurent, mais pas l’état D1, R2 ou KV. | Preuve de rollback données toujours requise |
+
+## Incompatibilités et contraintes détaillées
+
+### 1. Astro face à OpenNext
+
+Le script de déploiement SuperBoard génère une configuration Dashboard, exécute opennextjs-cloudflare build, puis déploie apps/dashboard/.open-next/worker.js. EmDash demande Astro, @astrojs/cloudflare, @astrojs/react et son intégration emdash/astro. Les deux outputs n’ont ni le même entrypoint, ni les mêmes assets, ni les mêmes bindings générés. Sources : [déploiement SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-deploy.mjs), [configuration OpenNext](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/open-next.config.ts), [configuration EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/astro.config.mjs).
+
+Fait de frontière : le runtime Cloudflare n’empêche pas de déployer le paquet Astro. En revanche, aucune preuve ne permet de considérer EmDash comme une intégration directement ajoutable au bundle Next actuel. Que le Site Astro remplace le service Dashboard, soit déployé comme service transitoire, ou soit placé derrière un Worker d’aiguillage est une décision d’architecture ultérieure.
+
+Astro 6 et suivants déterminent l’environnement Cloudflare pendant le build. Chaque cible doit donc exécuter son propre build avant déploiement. Cette contrainte correspond au principe SuperBoard d’un code canonique et de builds dérivés des manifests, mais la commande actuelle est spécifique à OpenNext. Source : [adapter Astro Cloudflare, changement des environnements](https://docs.astro.build/en/guides/integrations-guide/cloudflare/).
+
+### 2. Resources D1, R2 et KV absentes
+
+Ni le schéma deploy/targets/schema.json, ni mbza-development, ni vocostar ne déclarent un CMS, un D1 EmDash, un bucket MEDIA EmDash, un KV SESSION ou un KV CACHE EmDash. Le registre des services refuse tout service extérieur à sa liste, et le registre D1 refuse tout propriétaire extérieur à sa liste. Sources : [schéma de cible](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/schema.json), [registre de services](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-services.mjs), [registre D1](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-registry.mjs).
+
+La D1 d’EmDash contient à la fois l’administration, l’authentification, le modèle de contenu, le contenu et le stockage logique des plugins. Le bridge sandboxé accède directement à DB et MEDIA du Worker hôte. Il n’est pas possible de remplacer ce D1 par une liste de Service bindings vers les D1 métiers existantes sans réécrire l’adapter et le bridge. Sources : [runner sandbox](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/runner.ts), [bridge sandbox](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/bridge.ts).
+
+L’adapter R2 natif ne fournit pas d’URL signée ; les uploads passent par le Worker. EmDash fixe par défaut son upload maximal à 50 MiB. Les manifests SuperBoard fixent 10 MiB en développement et 50 MiB en production pour le service Files, mais cette règle ne s’applique pas automatiquement au Site EmDash. La politique média du CMS doit donc être explicitement alignée. Sources : [stockage EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/docs/src/content/docs/deployment/storage.mdx), [configuration EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/docs/src/content/docs/reference/configuration.mdx), [cibles SuperBoard](https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets).
+
+### 3. D1 Sessions et global_fetch_strictly_public
+
+Le mode D1 session d’EmDash est désactivé par défaut, mais son démonstrateur Cloudflare utilise session auto pour les read replicas. EmDash documente qu’avec global_fetch_strictly_public, la requête interne des D1 Sessions est bloquée et peut rester suspendue jusqu’à l’arrêt du Worker. Le code courant contient un garde de cinq secondes qui abandonne la session et revient au binding direct, mais ce fallback ne transforme pas cette combinaison en configuration saine ou en preuve de réplication. Sources : [documentation Cloudflare EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/docs/src/content/docs/deployment/cloudflare.mdx), [adapter D1 EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/db/d1.ts), [garde de session](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/db/d1-session-guard.ts).
+
+Cloudflare confirme que la réplication de lecture exige D1 Sessions et que les sessions fournissent la cohérence séquentielle par bookmarks. Cloudflare décrit par ailleurs global_fetch_strictly_public comme un routage de fetch par la porte publique de la zone. Sources : [réplication D1](https://developers.cloudflare.com/d1/best-practices/read-replication/), [flags Workers](https://developers.cloudflare.com/workers/configuration/compatibility-flags/).
+
+Conséquence factuelle : la fonction baseConfig de SuperBoard ne peut pas être réutilisée sans décision pour un EmDash qui active D1 Sessions. Les deux états possibles à étudier plus tard sont une politique de flags différente pour le CMS ou des sessions D1 désactivées ; cette note ne choisit pas.
+
+### 4. Dynamic Workers, plans, facturation et concurrence
+
+Le Worker Loader est devenu la primitive Dynamic Workers de Cloudflare. Il permet de composer un isolate à l’exécution, de contrôler ses bindings, son accès réseau et ses limites. Il est actuellement disponible uniquement avec Workers Paid. Workers Paid est un abonnement distinct du plan de zone Cloudflare et commence à 5 USD par compte et par mois. Puisque les cibles SuperBoard peuvent appartenir à des comptes distincts, chaque compte exécutant les plugins sandboxés doit avoir l’entitlement. Sources : [Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/), [tarification Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/pricing/), [tarification Workers](https://developers.cloudflare.com/workers/platform/pricing/), [cibles SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/README.md).
+
+Au 29 août 2026 :
+
+- 1 000 Dynamic Workers uniques par mois sont inclus ;
+- l’excédent est facturé 0,002 USD par Dynamic Worker et par jour ;
+- les appels RPC et fetch comptent comme requêtes Worker ;
+- le CPU de démarrage et le CPU d’exécution sont facturés ;
+- un même identifiant et le même code réutilisés avec get comptent une fois par jour ;
+- un même identifiant avec un code différent compte comme une nouvelle création.
+
+EmDash utilise l’identifiant plugin-id:version avec loader.get, puis invoque les hooks et routes par RPC. Cette forme est cohérente avec la réutilisation facturable de Cloudflare, à condition que les versions de plugin identifient réellement leur code. Sources : [runner EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/runner.ts), [tarification Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/pricing/).
+
+Cloudflare limite à quatre le nombre de Dynamic Workers distincts ayant des requêtes simultanément en vol dans le contexte d’une requête Worker. EmDash exécute séquentiellement les hooks beforeSave, beforeDelete et page:metadata, mais construit un tableau de promesses puis appelle Promise.allSettled pour afterSave, afterDelete et plusieurs hooks différés. Plus de quatre plugins distincts actifs sur un tel événement peuvent donc atteindre la limite de plateforme. Sources : [limites Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/platform/limits/), [orchestration de hooks EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/core/src/emdash-runtime.ts).
+
+EmDash fixe par défaut des limites plus basses par plugin : 50 ms CPU, dix subrequests et trente secondes de wall time. Cloudflare sait appliquer CPU et subrequests ; la wall time est imposée par Promise.race dans EmDash. La mémoire déclarée de 128 MiB n’est pas configurable par isolate dans le runner. Source : [runner EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/runner.ts), [limites personnalisées Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/usage/limits/).
+
+Workers for Platforms n’est pas utilisé par le démonstrateur ou le runner EmDash : aucun dispatch namespace n’est déclaré. Il n’est donc pas un prérequis constaté. Il deviendrait pertinent uniquement si une décision ultérieure transformait SuperBoard en plateforme déployant des Workers clients persistants via des namespaces, ce qui dépasse cette enquête. Sources : [fonctionnement de Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/how-workers-for-platforms-works/), [Wrangler EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/wrangler.jsonc).
+
+### 5. Service bindings et Workers métier
+
+Les Service bindings peuvent relier le Worker Astro à l’API et aux autres Workers SuperBoard sans URL publique. Le Worker cible doit se trouver dans le même compte Cloudflare. Une requête peut traverser au maximum trente-deux invocations Worker ; chaque appel de binding compte aussi comme subrequest. Le Worker cible doit être déployé avant le Worker appelant. Sources : [Service bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/), [ordre de déploiement SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-deploy-plan.mjs).
+
+Cloudflare Access ne propage pas automatiquement son contexte ctx.access dans un Service binding. Le Worker aval ne doit donc pas considérer l’appel comme authentifié sans contrat explicite. Source : [Service bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/).
+
+Le bridge sandbox d’EmDash n’expose pas les Service bindings arbitraires du Worker hôte. Son ctx.http vérifie une capability réseau, une liste d’hôtes et les redirections, puis utilise globalThis.fetch. Les plugins sandboxés peuvent donc appeler un endpoint public autorisé, mais pas invoquer directement API_SERVICE, FILES_SERVICE ou un autre binding privé SuperBoard avec l’API actuelle. Cloudflare permet techniquement d’exposer des custom bindings aux Dynamic Workers, mais EmDash devrait être étendu pour cela. Sources : [HTTP bridge EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/bridge-http.ts), [bindings Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/usage/bindings/).
+
+### 6. Routes, domaines et coexistence
+
+Un Custom Domain est l’origine Worker de tous les chemins d’un hostname exact. Le Dashboard SuperBoard possède déjà ce rôle sur board.mbza.dev et grow.vocostar.com. Une Route plus spécifique peut s’exécuter devant un Worker Custom Domain et appeler ensuite l’origine par fetch. Cloudflare choisit la route la plus spécifique lorsqu’il existe plusieurs patterns. Sources : [Custom Domains](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/), [Routes](https://developers.cloudflare.com/workers/configuration/routing/routes/).
+
+Ces primitives rendent une coexistence technique possible, mais aucun état actuel de SuperBoard ne déclare :
+
+- un hostname de prévisualisation EmDash ;
+- un Worker CMS ;
+- une propriété séparée des chemins /_emdash ;
+- un aiguillage entre OpenNext et Astro ;
+- un reçu liant la parité à un changement de route.
+
+Le gate public-routing de SuperBoard protège les hostnames actuels ; le nouveau propriétaire et la séquence de transfert devront y être ajoutés avant toute mutation. Sources : [gate de routage](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/public-routing-gate.mjs), [plan de domaines](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-domain-plan.mjs).
+
+Cloudflare conserve des versions complètes du code, des assets, bindings et réglages du Worker. Un déploiement peut contenir deux versions et partager progressivement le trafic. Pour des assets hashés, la version affinity est nécessaire afin d’éviter qu’un HTML d’une version demande un asset uniquement présent dans l’autre. Sources : [versions et déploiements](https://developers.cloudflare.com/workers/versions-and-deployments/), [version affinity](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/).
+
+Un rollback Worker ne restaure pas les données D1, R2 ou KV, et peut être refusé si une ressource attendue a été supprimée. La preuve de rollback exigée par la carte doit donc couvrir séparément le routage, le code, les sessions, les médias et la base. Source : [rollbacks Workers](https://developers.cloudflare.com/workers/versions-and-deployments/rollbacks/).
+
+### 7. Migrations et sauvegardes
+
+EmDash sépare les migrations internes du CMS de l’évolution des collections. Un build Astro génère .emdash/migrations.json avec la version, l’ordre des migrations et l’exécuteur. La CLI peut afficher le statut, appliquer avec un fingerprint de cible, puis vérifier. Sur D1, EmDash demande de sérialiser les jobs par compte et UUID de base, car D1 ne fournit pas de verrou consultatif de migration. Le runtime auto-migre par défaut ; les modes check et manual permettent de déplacer la mutation dans le déploiement. Source : [migrations core EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/docs/src/content/docs/deployment/core-migrations.mdx).
+
+Ce modèle peut respecter l’intention du gate SuperBoard, mais son format n’est pas celui que SuperBoard exécute aujourd’hui. SuperBoard :
+
+- ne reconnaît que des fichiers SQL nommés et triés dans un migrations_dir ;
+- interroge wrangler d1 migrations list ;
+- exporte chaque base avant la première écriture ;
+- applique wrangler d1 migrations apply ;
+- vérifie un reçu de lot avant de déployer les Workers.
+
+Sources : [registre D1](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-registry.mjs), [convergence D1](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-converge.mjs), [workflow de production](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/.github/workflows/deploy-cloudflare.yml).
+
+L’incompatibilité la plus dure est la sauvegarde. La fonction SuperBoard appelle wrangler d1 export sur toute base propriétaire de schéma avant migration, refuse skip-backup en production, chiffre ensuite les exports et conserve les artefacts. Cloudflare indique que l’export n’est pas supporté pour une base contenant des tables virtuelles. EmDash active la recherche SQLite avec des tables CREATE VIRTUAL TABLE ... USING fts5 pour les collections recherchables. Sources : [backup SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-backup.mjs), [déploiement SuperBoard](https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-deploy.mjs), [export D1](https://developers.cloudflare.com/d1/best-practices/import-export-data/), [FTS EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/core/src/search/fts-manager.ts).
+
+Cette incompatibilité apparaît dès qu’au moins une collection EmDash possède un index FTS5 ; elle ne doit pas être supposée sur une base fraîche sans recherche. Elle empêche néanmoins de considérer le pipeline complet comme compatible, car la recherche fait partie des capacités normales d’EmDash.
+
+D1 Time Travel est toujours activé et permet un retour à la minute jusqu’à trente jours sur Workers Paid, contre sept jours sur Free. La restauration écrase la base en place et annule les requêtes en vol. Cette capacité est une ressource de récupération, pas une équivalence automatique à l’export chiffré et hors compte exigé aujourd’hui par SuperBoard. Sources : [Time Travel D1](https://developers.cloudflare.com/d1/reference/time-travel/), [limites D1](https://developers.cloudflare.com/d1/platform/limits/).
+
+### 8. Développement local
+
+Cloudflare simule localement D1, R2, KV et les Service bindings dans workerd/Miniflare. Les ressources locales sont vides au départ et sont persistées par défaut sous .wrangler/state ; elles n’accèdent pas aux données de production sauf binding remote explicite. Plusieurs Workers peuvent être démarrés ensemble avec plusieurs fichiers de configuration ou séparément et reliés par Service bindings. Sources : [données locales](https://developers.cloudflare.com/workers/local-development/local-data/), [multi-Workers local](https://developers.cloudflare.com/workers/local-development/multi-workers/), [support des bindings](https://developers.cloudflare.com/workers/local-development/bindings-per-env/).
+
+La matrice Cloudflare courante ne liste pas Dynamic Worker Loaders parmi les bindings simulés localement ou reliés à distance. Le démonstrateur EmDash complet inclut en plus AI Search et des capacités média qui nécessitent une connexion distante. Lors de cette enquête, astro preview sur la release a demandé de sélectionner un compte pour établir une remote proxy session ; l’opération a été annulée avant tout accès distant. Il n’existe donc pas ici de preuve que la totalité du sandbox plugin peut être testée hors ligne.
+
+Le dépôt EmDash fournit des pages manuelles sandbox-test et sandbox-plugin-test, mais aucun test automatisé trouvé n’exécute un vrai Worker Loader Cloudflare dans le pipeline de la release ; les tests unitaires du runner utilisent des mocks. Sources : [page sandbox simple](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/src/pages/sandbox-test.astro), [page sandbox complète](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/demos/cloudflare/src/pages/sandbox-plugin-test.astro), [tests Cloudflare EmDash](https://github.com/emdash-cms/emdash/tree/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/tests).
+
+Prérequis factuel : la migration doit posséder deux niveaux de preuve distincts, un environnement local déterministe pour D1/R2/KV et Workers métier, puis une acceptance sur le compte mbza-development pour LOADER et toute capacité non simulée.
+
+### 9. Observabilité
+
+Le Worker hôte EmDash peut recevoir exactement les réglages de Workers Logs, traces et tail_consumers déjà générés par SuperBoard. Workers Logs sur Paid conserve au maximum sept jours, avec vingt millions d’événements inclus par mois ; la taille maximale d’un log est 256 Ko. Les métriques Worker sont consultables jusqu’à trois mois. Les traces sont encore en beta le 29 août 2026 et leur facturation doit commencer le 1er octobre 2026. Sources : [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/), [métriques](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/), [traces](https://developers.cloudflare.com/workers/observability/traces/).
+
+Les Dynamic Workers sont des contexts séparés. Cloudflare exige de leur attacher un Tail Worker dans la propriété tails pour conserver leurs console.log, exceptions et métadonnées. Activer observability sur le loader ne capture que le loader. Le runner EmDash 0.35.0 construit ses isolates avec modules, globalOutbound, limits et env, mais sans tails. Son API ctx.log appelle le PluginBridge, qui écrit avec console dans le Worker hôte ; ce chemin contrôlé est visible, contrairement aux logs directs de l’isolate. Sources : [observabilité Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/usage/observability/), [runner EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/runner.ts), [bridge EmDash](https://github.com/emdash-cms/emdash/blob/3c99225d80a38a9751ed0e4b56e3924e40308e70/packages/cloudflare/src/sandbox/bridge.ts).
+
+Le Worker observability de SuperBoard est un Tail Worker Paid et peut rester le collecteur du host. Il ne devient pas automatiquement le tail de chaque plugin dynamique ; une adaptation et une preuve de corrélation plugin, version, cible, requête et release sont nécessaires.
+
+## Limites et coûts à inscrire dans le gate
+
+Les chiffres suivants proviennent de la documentation Cloudflare courante au 29 août 2026. Ils ne constituent pas une estimation de facture SuperBoard.
+
+| Produit | Limite ou inclusion courante | Incidence vérifiable |
+| --- | --- | --- |
+| Workers Paid | Minimum 5 USD par compte/mois ; 10 M requêtes et 30 M ms CPU inclus | Requis par Dynamic Workers sur chaque compte cible |
+| Worker | 10 MiB gzip Paid, 128 MiB mémoire, 500 Workers, 250 Cron Triggers | Le paquet EmDash mesuré tient ; mémoire runtime non mesurée |
+| Worker | 10 000 subrequests Paid, 32 invocations Worker par requête | Borne les graphes de Service bindings et plugins |
+| Dynamic Workers | 1 000 uniques/mois inclus, puis 0,002 USD par Worker/jour | Dépend du nombre de plugins et versions effectivement invoqués |
+| Dynamic Workers | 4 isolates distincts simultanés par requête Worker | Conflit possible avec le fan-out parallèle des hooks EmDash |
+| D1 Paid | 50 000 DB par compte, 10 Go par DB, 1 To par compte | Nombre de DB non bloquant ; 10 Go par Site est une borne dure |
+| D1 Paid | 1 000 requêtes DB par invocation, ligne/BLOB 2 Mo, 100 colonnes/table | À vérifier contre les contenus Portable Text et collections réels |
+| D1 Paid | 30 jours Time Travel | Retour base possible, destructif et non hors compte |
+| R2 | 5 Tio par objet, 5 Gio en upload simple, 4,995 Tio multipart | EmDash limite par défaut à 50 Mio avant ces plafonds |
+| R2 Standard | 10 Go-mois, 1 M opérations A et 10 M opérations B inclus | À mesurer sur les médias et leur lecture |
+| KV Paid | valeur 25 Mio, 1 écriture/s sur une même clé | Sessions/cache possibles ; hotspots d’invalidation à tester |
+| KV Paid | 10 M lectures, 1 M écritures, 1 Go inclus par mois | SESSION et CACHE ont des profils séparés |
+| Routes | 1 000 routes/zone, 100 Custom Domains/zone | Pas de pression quantitative constatée |
+
+Sources : [limites Workers](https://developers.cloudflare.com/workers/platform/limits/), [tarification Workers](https://developers.cloudflare.com/workers/platform/pricing/), [tarification Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/pricing/), [limites Dynamic Workers](https://developers.cloudflare.com/dynamic-workers/platform/limits/), [limites D1](https://developers.cloudflare.com/d1/platform/limits/), [tarification D1](https://developers.cloudflare.com/d1/platform/pricing/), [limites R2](https://developers.cloudflare.com/r2/platform/limits/), [tarification R2](https://developers.cloudflare.com/r2/pricing/), [limites KV](https://developers.cloudflare.com/kv/platform/limits/), [tarification KV](https://developers.cloudflare.com/kv/platform/pricing/).
+
+Le plafond de corps de requête dépend du plan de zone et non du plan Workers : 100 Mo sur Free/Pro, 200 Mo sur Business et 500 Mo par défaut sur Enterprise. Le maximum EmDash de 50 MiB reste sous le plus petit plafond documenté, mais la politique SuperBoard de développement à 10 MiB n’est pas automatiquement respectée. Source : [limites Workers](https://developers.cloudflare.com/workers/platform/limits/).
+
+## Mesures reproductibles effectuées
+
+Les commandes suivantes ont été exécutées dans un worktree détaché du clone complet EmDash au commit de release 3c99225d80a38a9751ed0e4b56e3924e40308e70 :
+
+1. pnpm install --frozen-lockfile
+2. pnpm --filter @emdash-cms/demo-cloudflare build:all
+3. pnpm exec wrangler deploy --dry-run --outdir /tmp/emdash-dry-run-release-0.35.0-20260829
+
+Environnement de mesure : Node 26.7.0, pnpm 11.9.0 et Wrangler 4.124.0 issu du lock EmDash.
+
+Résultat release 0.35.0 :
+
+- installation réussie, avec avertissement de dépendance workspace cyclique entre auth-atproto et core ;
+- build source et build Astro réussis ;
+- avertissements présents : export handleSchemaCollectionReorder manquant pendant le build du package core, imports virtuels laissés externes pendant le build du package Cloudflare, imports dynamiques inefficaces et chunks client supérieurs à 500 Ko ;
+- dry-run Wrangler réussi ;
+- 426 modules Worker ;
+- 10 179,63 KiB upload total, 2 551,09 KiB gzip ;
+- 66 fichiers assets ;
+- bindings générés : SESSION, DB, AI_SEARCH, MEDIA, ASSETS et LOADER.
+
+Le même contrôle au HEAD 1717d31b351164a5f78e95fe004ee582c7c50f40 a produit 437 modules, 10 598,23 KiB total et 2 675,75 KiB gzip. Les deux paquets sont sous la limite Paid de 10 MiB gzip ; la release ne rentrerait pas sous la limite Free de 3 MiB avec une marge suffisante pour la migration, et Dynamic Workers impose Paid de toute façon.
+
+Le build réussi n’est pas une preuve de comportement fonctionnel ou de charge. Les avertissements empêchent de qualifier la construction source de propre. La mesure prouve seulement que le bundle officiel est accepté par le dry-run de son Wrangler épinglé et respecte les limites statiques mesurables.
+
+## Prérequis bloquants avant le gate d’architecture
+
+Les éléments suivants doivent devenir des décisions ou preuves séparées ; ils ne sont pas des tâches de construction autorisées par ce ticket de recherche.
+
+1. **Épingler la source EmDash.** Choisir explicitement entre l’artefact publié 0.35.0 à 3c99225d… et un commit post-release. Interdire main, latest et un simple numéro 0.35.0 construit depuis un checkout différent comme identité de release.
+2. **Modéliser le CMS dans le control plane.** Ajouter un service ou un remplacement de service reconnu par les manifests, le schéma, la liste de déploiement, les checks, les types, les secrets et les moniteurs. La forme exacte reste à décider.
+3. **Déclarer chaque ressource par cible.** D1 DB, R2 MEDIA, KV SESSION, Worker Loader, Cron et EMDASH_ENCRYPTION_KEY sont le minimum observé avec plugins sandboxés. KV CACHE, AI_SEARCH, Images, Email et OAuth sont conditionnels. Aucun auto-provisionnement silencieux ne doit échapper à l’inventaire cible.
+4. **Vérifier Workers Paid sur chaque compte.** mbza-development et chaque cible de production utilisant LOADER doivent être éligibles et budgétées. Le code ne peut pas prouver cet entitlement.
+5. **Remplacer ou isoler le build OpenNext.** Produire l’artefact Astro par cible avec une version de Wrangler éprouvée, sans supposer que .open-next et dist/server sont interchangeables.
+6. **Intégrer les migrations EmDash.** Conserver ensemble artefact et .emdash/migrations.json, sérialiser par compte/UUID, appliquer avec fingerprint, vérifier avant trafic et faire reconnaître le résultat par le reçu de déploiement SuperBoard.
+7. **Résoudre la sauvegarde FTS5.** Fournir un mécanisme vérifié pour sauvegarder et restaurer une D1 EmDash avec tables virtuelles tout en conservant les garanties de chiffrement, rétention hors checkout et reçu. wrangler d1 export seul ne satisfait pas ce besoin.
+8. **Fixer la politique D1 Sessions.** Prouver soit le fonctionnement sans global_fetch_strictly_public pour le Site, soit le fonctionnement avec sessions désactivées. Ne pas déployer session auto avec le baseConfig actuel.
+9. **Borner les hooks sandboxés.** Prouver le comportement avec plus de quatre plugins concernés, puis imposer une stratégie qui respecte la limite Cloudflare. Le fan-out actuel ne constitue pas cette preuve.
+10. **Définir les contrats vers les Workers métier.** Lister les appels qui utilisent une URL publique, un Service binding du host ou une nouvelle capability bridge. Respecter la contrainte de même compte et ne pas compter sur la propagation de Cloudflare Access.
+11. **Compléter l’observabilité.** Relier le Worker hôte au collecteur SuperBoard et décider si les logs/exceptions directs des Dynamic Workers doivent être tailés. Ajouter corrélation et tests d’alerte.
+12. **Prouver local puis mbza-development.** Séparer les tests locaux D1/R2/KV/multi-Workers de l’acceptance distante LOADER, sans accès implicite aux données de production.
+13. **Créer le plan de route et rollback.** Définir qui possède le Custom Domain à chaque phase, comment les assets restent affines, comment l’ancienne version est rappelée, et comment les mutations D1/R2/KV sont récupérées indépendamment du code.
+14. **Mesurer la capacité réelle.** Taille D1 projetée, taille maximale d’une entrée, nombre de champs, volume médias, fréquence KV, nombre de plugins, fan-out et CPU/mémoire du SSR. Les limites de plateforme seules ne prouvent pas la marge en charge.
+
+## Faits encore inconnus
+
+Cette enquête ne prétend pas connaître :
+
+- le plan Workers réellement actif sur les comptes mbza-development et vocostar ;
+- le nombre, la taille et la localisation des ressources Cloudflare déjà provisionnées hors manifests ;
+- le volume final du contenu et des médias après migration ;
+- le nombre de plugins sandboxés simultanément actifs ;
+- la charge CPU et mémoire du Front SuperBoard rendu par EmDash ;
+- la stratégie d’authentification finale entre EmDash, Identity et les SDK ;
+- la stratégie de propriété du domaine pendant le cutover ;
+- la solution de sauvegarde FTS5 ou de restauration hors compte ;
+- la parité fonctionnelle et visuelle du Dashboard.
+
+Ces inconnues ne contredisent pas les faits établis. Elles interdisent simplement de qualifier la migration de prête à construire ou à basculer.
+
+## Conclusion
+
+Le socle Cloudflare est assez riche pour héberger EmDash : Worker Astro SSR, D1, R2, KV, Service bindings, Dynamic Workers, routes, versions et observabilité existent et le bundle publié passe le dry-run. Le nombre actuel de Workers SuperBoard et la taille du bundle EmDash ne saturent pas les limites Paid.
+
+Le chemin n’est cependant pas une substitution de package dans apps/dashboard. Il faut intégrer un runtime Astro et un nouveau jeu de ressources dans le control plane, traiter deux incompatibilités de production — sauvegarde D1 avec FTS5 et D1 Sessions face à global_fetch_strictly_public —, borner les Dynamic Workers, compléter leurs logs et construire une preuve de route et de rollback qui inclut les données.
+
+La décision d’architecture peut partir de ces contraintes. Elle ne doit considérer aucune de ces incompatibilités comme déjà résolue.

--- a/docs/SUPERBOARD_CURRENT_STATE_INVENTORY_2026-08-29.md
+++ b/docs/SUPERBOARD_CURRENT_STATE_INVENTORY_2026-08-29.md
@@ -1,0 +1,617 @@
+# Inventaire de l’état actuel de SuperBoard — 29 août 2026
+
+> Recherche pour [Inventorier la surface et les contrats actuels de SuperBoard](https://github.com/mabzadev/superboard/issues/35), enfant de la carte [Migration complète de SuperBoard vers EmDash CMS](https://github.com/mabzadev/superboard/issues/33).
+>
+> Référence immuable : [`d1850233e97b79c3cde7eae18a0123d4d39c8ae2`](https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2), commit du 13 août 2026. Tous les liens de source « livré », « partiel » ou « historique » ci-dessous sont épinglés à ce SHA.
+
+## Réponse courte
+
+La migration EmDash doit préserver bien davantage qu’une liste d’écrans. Au commit de référence, SuperBoard est un plan de contrôle composé de quatre couches liées :
+
+1. un Dashboard Next.js/OpenNext de **93 pages**, dont **84 sous la garde cliente protégée**, avec 10 sections et 60 destinations de navigation explicites ;
+2. un Worker API Hono qui conserve les contrats historiques et agit comme gateway vers huit Workers de domaine au moyen d’un contexte de projet signé ;
+3. un graphe Cloudflare déclaratif de Workers, D1, KV, R2, Queues, DLQ, Durable Objects, Workflows, Containers, Analytics Engine et Service Bindings ;
+4. des SDK et consommateurs dont la compatibilité repose encore sur des versions OpenGrow publiées pendant que les deux SDK SuperBoard 3.0 actifs restent en attente de release.
+
+Le commit contient une surface riche et testée, mais il ne constitue pas une production totalement convergée. Le target de développement MBZA est en routage public actif ; le target VocoStar est en routage privé `staged`, désactive Analytics et Messaging, n’a pas de reçu de convergence FlutterFlow, et son pont voix/média présente trois blocages explicites. Support reste en transition depuis Chatwoot/OpenChat et l’ancien Worker Messaging demeure une compatibilité historique. L’inventaire local calcule 320 routes Worker et 120 tables D1, mais la comparaison avec l’ancien upstream est indisponible et volontairement retirée comme gate de release. [Sources : gouvernance][adr-canonical], [inventaire][inventory-script], [target MBZA][target-mbza], [target VocoStar][target-vocostar], [plan de déploiement][deploy-plan].
+
+La frontière à préserver peut se résumer ainsi :
+
+```mermaid
+flowchart LR
+  operator[Opérateur] --> dashboard[Dashboard Next/OpenNext]
+  dashboard --> bff[BFF auth /api/auth/*]
+  dashboard --> api[API Hono]
+  apps[Apps + SDK + FlutterFlow] --> api
+  mcp[MCP local et Worker] --> api
+  api --> central[(D1 central + KV + R2)]
+  api --> modules[8 Workers de domaine]
+  api --> common[Identity · Files · Email · Billing · Observability]
+  modules --> stores[(D1 de module · R2 · Queues · DO · Workflows)]
+  custom[Worker custom par target] --> api
+  custom --> managed[Workflows/Containers VocoStar]
+```
+
+## Méthode et légende
+
+L’inventaire a été produit dans un worktree isolé créé directement depuis le SHA ci-dessus. Les seules autorités utilisées sont le code, les tests, les manifestes, les schémas, les migrations et la documentation du dépôt à ce commit. Les affirmations sur le checkout partagé non validé sont isolées dans une section dédiée et ne reçoivent volontairement aucun permalink : par définition, GitHub ne peut pas épingler un fichier qui n’est pas commité.
+
+Les statuts signifient :
+
+| Statut | Sens précis dans ce document |
+| --- | --- |
+| **Livré** | Présent au commit, relié à la surface d’exécution ou à un gate. Cela ne prouve pas à lui seul l’état du runtime distant. |
+| **Partiel / bloqué** | Présent au commit, mais un manifeste, un gate, un reçu, une migration ou une preuve externe reste explicitement incomplet. |
+| **Historique / compatibilité** | Conservé pour rollback, migration ou anciens clients ; il ne doit pas devenir la nouvelle autorité EmDash. |
+| **Checkout non validé** | Différence locale par rapport au SHA, non commitée et non livrée. |
+
+Le dépôt ne contient pas, à ce commit, les fichiers `CONTEXT-MAP.md`, `CONTEXT.md`, `apps/CONTEXT.md` et `workers/CONTEXT.md` mentionnés plus tard dans la carte Wayfinder. Le vocabulaire ci-dessous est donc dérivé des autorités réellement présentes : [manifestes de target][target-schema], [registre de services][service-registry], [contrats partagés][contracts-index] et [documentation d’architecture][architecture].
+
+## 1. Dashboard : shell, routes, navigation et états
+
+### 1.1 Contrat du shell
+
+Le Dashboard est une application Next.js 16 rendue sur Cloudflare Workers avec OpenNext. Le layout racine installe thèmes, TanStack Query, contexte utilisateur, analytics et notifications. Le layout protégé ajoute la garde d’authentification, le sélecteur de projet/environnement, la sidebar, le header et les providers de dialogs. La configuration de build dérive les URL publiques et le client OAuth du target ; `CLIENT_SECRET` reste côté serveur. [Sources : package Dashboard][dashboard-package], [layout racine][dashboard-root-layout], [layout protégé][dashboard-protected-layout], [build Cloudflare][dashboard-cloudflare], [configuration Next][dashboard-next].
+
+Contrats d’état à préserver :
+
+- la racine `/` redirige vers `/login` ou `/dashboard` selon la présence d’un token local ; [source][dashboard-root-page]
+- la garde est **cliente**, pas un middleware serveur : elle lit `access_token`, accepte aussi `token` et `refresh_token` dans l’URL pour compatibilité, les retire immédiatement de l’historique, charge `/users/me`, puis renvoie vers `/login?backTo=...` si nécessaire ; [source][protected-route]
+- le BFF `/api/auth/token` échange email, mot de passe et OTP contre OAuth auprès de l’API avec le secret serveur, puis charge l’utilisateur ; `/api/auth/refresh` et `/api/auth/revoke` protègent les autres opérations sensibles ; [sources : token][auth-token-route], [refresh][auth-refresh-route], [revoke][auth-revoke-route]
+- le navigateur conserve `access_token`, `refresh_token`, `current_user` et `login_type` dans `localStorage`; le client API ajoute `Authorization: Bearer`, crée une clé d’idempotence sur les mutations, retente les méthodes idempotentes sur 500/502/503/504 et sérialise un seul refresh après 401 ; [sources : stockage][local-storage], [client HTTP][dashboard-api-client], [refresh][dashboard-refresh]
+- l’instance sélectionnée et l’environnement `production` ou `test` sont reflétés dans `instance_id` et `env_type` dans la query string. Une instance inaccessible retombe sur la plus récente ; l’absence de toute instance ouvre le formulaire de premier projet ; [sources : layout client][dashboard-client-layout], [contexte projet][dashboard-project-context]
+- les pages utilisent des limites d’erreur globales, protégées et locales, des squelettes de chargement et une page 404. Les surfaces métier exposent également des états vides, `unavailable`, `disabled`, `misconfigured`, `degraded`, ainsi que la santé de schéma `current`, `behind` ou `drifted`. [Sources : erreur protégée][dashboard-protected-error], [erreur globale][dashboard-global-error], [loading][dashboard-protected-loading], [404][dashboard-not-found], [contrat Infrastructure][platform-status-route].
+
+### 1.2 Surface de routes
+
+Le comptage du tree donne 93 `page.tsx`, 19 `layout.tsx`, 4 route handlers Next, 6 limites d’erreur, 5 fichiers de chargement et une 404. Les 84 pages protégées partagent le même shell. Le tableau suivant est l’index de parité à conserver ; les routes de détail dynamiques sont indiquées comme patterns. [Source : arbre App Router][dashboard-app-tree].
+
+| Surface | Routes présentes au commit | État et backing |
+| --- | --- | --- |
+| Entrée et compte public | `/`, `/login`, `/register`, `/register/with_email`, `/reset_password`, `/new_password`, `/accept-invite` | **Livré.** Compte Dashboard, invitation, reset, OTP et redirections sont reliés à l’API centrale. [Sources : service utilisateur][dashboard-user-service], [contexte utilisateur][dashboard-user-context] |
+| OAuth/MCP et preview | `/mcp/authorize`, `/message-preview-craft` | **Livré.** Ces routes sont hors du groupe protégé ; MCP effectue ses propres contrôles, tandis que la preview Craft est une surface de rendu isolée à auditer lors de la migration. [Sources : consentement MCP][dashboard-mcp-authorize], [preview][dashboard-message-preview] |
+| BFF/health Next | `/api/health`, `/api/auth/token`, `/api/auth/refresh`, `/api/auth/revoke` | **Livré.** Ces quatre handlers sont distincts de l’API Worker publique. [Source][dashboard-api-routes] |
+| Shell opérateur | `/dashboard`, `/account`, `/infrastructure`, `/project-settings` | **Livré.** Account, Infrastructure et Project Settings sont accessibles depuis le menu utilisateur, pas depuis les 10 sections principales. [Sources : menu utilisateur][dashboard-user-nav], [header][dashboard-header] |
+| App | `/app/customers`, `/app/users`, `/app/referrals`, `/app/access-key`, `/app/libraries`, `/app/android-setup`, `/app/ios-setup`, `/app/web-setup` | **Livré.** Données App, utilisateurs Identity/Billing, catalogue SDK et configuration par plateforme. [Sources : navigation][dashboard-navigation], [service App][dashboard-app-api], [wizard SDK][dashboard-sdk-wizard] |
+| Identity | `/identity`, `/identity/[lang]`, puis `dashboard`, `users`, `users/[authId]`, `user-attributes`, `user-attributes/new`, `user-attributes/[id]`, `roles`, `roles/new`, `roles/[id]`, `apps`, `apps/new`, `apps/[id]`, `apps/banners/new`, `apps/banners/[id]`, `scopes`, `scopes/new`, `scopes/[id]`, `orgs`, `orgs/new`, `orgs/[id]`, `logs`, `logs/email/[id]`, `logs/sign-in/[id]`, `logs/sms/[id]`, `saml`, `saml/new`, `saml/[id]`, `account` | **Livré en source.** Le segment de langue accepte au moins `en`/`fr`; le target désactive SSO par défaut. L’admin Melody est proxifié par le Worker Identity. [Sources : arbre Identity][dashboard-identity-tree], [Worker Identity][identity-worker], [targets][target-mbza] |
+| Products | `/products/purchases`, `/products/customers`, `/products/offerings`, `/products/entitlements` | **Livré.** Catalogue/offerings/entitlements viennent des Workers Products/Billing ; Customers a une surface Billing dédiée. [Sources : pages][dashboard-products-pages], [Worker Products][products-worker], [API Billing][billing-routes] |
+| Paywalls | `/paywalls`, `/paywalls/statistics` | **Livré.** Définitions, versions publiées/archivées, placements, expériences, variants et statistiques. [Sources : pages][dashboard-paywalls-page], [Worker][paywalls-worker] |
+| Dynamic Links | `/dynamic-links/links`, `/dynamic-links/campaigns`, `/dynamic-links/campaigns/[id]`, `/dynamic-links/redirect-rules`, `/dynamic-links/domain`, `/dynamic-links/social-media-preview`, `/dynamic-links/tracking` | **Livré.** CRUD, résolution, campagnes, règles, domaines, social preview, tracking et statistiques. [Sources : navigation][dashboard-navigation], [Worker][dynamic-links-worker] |
+| Support | `/support/inbox`, `/support/configuration`, `/support/contacts`, `/support/quality` | **Livré en source, convergence VocoStar partielle.** Inbox, realtime, pièces jointes, contacts, sociétés, notes, configuration, audit, CSAT, webhooks et DLQ existent ; la migration Chatwoot/OpenChat et le retrait du legacy ne sont pas terminés. [Sources : Worker][support-worker], [architecture Support][messaging-architecture], [convergence][openchat-convergence] |
+| Marketing | `/marketing/in-app-messages`, `/marketing/email`, `/marketing/campaigns`, `/marketing/journeys`, `/marketing/channels`, `/marketing/statistics`, `/marketing/settings` | **Livré.** In-app historique/central, abonnés, consentement, listes, segments, templates, campagnes, journeys, connecteurs, SMTP, webhooks provider, outbox et dead letters. [Sources : pages][dashboard-marketing-pages], [Worker][marketing-worker] |
+| Analytics | `/analytics`, puis `dashboards`, `users`, `events`, `dimensions`, `views`, `installations`, `purchases`, `insights`, `cohorts`, `crashes`, `feedback`, `remote-config`, `alerts`, `reports`, `settings` | **Livré pour MBZA ; désactivé pour VocoStar.** Toutes les pages pointent vers le Worker Analytics, mais `features.analytics=false` sur VocoStar et son ID D1 est nul. [Sources : pages][dashboard-analytics-pages], [Worker][analytics-worker], [target][target-vocostar] |
+| Onboardings | `/onboardings`, `/onboardings/statistics` | **Livré.** Définitions/versioning, placements, targeting, expériences, résolution SDK, événements et statistiques. [Sources : pages][dashboard-onboarding-pages], [Worker][onboardings-worker] |
+
+### 1.3 Navigation et permissions
+
+`DASHBOARD_SECTIONS` code 10 sections et 60 liens ; le sous-menu de section normalise les langues Identity. La sidebar ne vient donc ni d’un CMS ni d’un registre runtime. Toute migration EmDash doit conserver une correspondance explicite entre slug de section, URL, renderer, état d’activation par target et permission avant de rendre cette configuration éditable. [Sources : registre de navigation][dashboard-navigation], [sidebar][dashboard-sidebar], [navigation de section][dashboard-section-nav].
+
+Le modèle d’autorisation visible est plus fin qu’un simple « connecté/non connecté » :
+
+- un utilisateur Dashboard peut avoir un rôle par instance ; les valeurs typées sont `owner`, `admin`, `member` ; [source][dashboard-instance-types]
+- certains contrôles UI sont seulement masqués aux non-`owner/admin` par `AdminOnlyDisplay` ; cette protection d’affichage n’est pas une autorité serveur ; [source][dashboard-admin-only]
+- l’API authentifie les bearer tokens stockés en D1, associe l’instance principale et applique ensuite ses propres contrôles ; [source][api-auth]
+- le gateway transforme l’instance et `production/test` en `projectRef` de forme `<instance>-prod|test`, refuse les mutations en maintenance read-only, exige une clé d’idempotence et signe un contexte HMAC pour le Worker de domaine ; [sources : gateway][domain-gateway], [contrat signé][project-context]
+- les Workers vérifient ce contexte avec une fenêtre d’horloge de 60 secondes. Analytics, Marketing et Support restreignent certaines mutations ou opérations à `owner/admin`; les rôles `sdk`, `application` et `system` existent pour des chemins non Dashboard. [Sources : Analytics][analytics-http], [Marketing][marketing-worker], [Support][support-worker]
+- l’endpoint Infrastructure exige `owner/admin`, même si la page peut être atteinte par tout utilisateur authentifié ; [source][platform-status-route].
+
+La migration ne doit donc pas déduire les permissions uniquement de la navigation actuelle. Il faut conserver les checks serveur comme autorité et construire séparément une matrice « route → capacité → rôle → target » pour le Front EmDash.
+
+## 2. API et contrats à préserver
+
+### 2.1 Surface du gateway
+
+Le Worker API monte les namespaces suivants. La liste est volontairement au niveau des contrats stables ; le fichier d’entrée et les routeurs liés contiennent l’inventaire endpoint par endpoint. [Sources : entrée API][api-index], [routeurs API][api-routes-tree].
+
+| Namespace public ou administratif | Responsabilité |
+| --- | --- |
+| `/health`, `/health/billing`, `/up`, `/.well-known/*` | Santé centrale, santé Billing, JWKS achats/Identity, métadonnées OAuth et associations mobile. |
+| `/oauth/*`, `/api/v1/auth/*`, `/api/v1/users/*` | Password/refresh/revoke OAuth Dashboard, utilisateur, invitation, reset et 2FA. |
+| `/auth/*` | Gateway d’identité application vers le Worker Identity. |
+| `/api/v1/instances/*`, `/api/v1/projects/*`, `/api/v1/links/*` | Instances, membres, plateformes, projets, métriques historiques, liens, campagnes, notifications et exports. |
+| `/api/v1/sdk/*` | Surface SDK historique plus achats v1/v2, custom jobs, Marketing preferences et effacement de compte. |
+| `/api/v1/{app,products,paywalls,dynamic-links,support,analytics,marketing,onboardings}/*` | Proxies Dashboard vers les huit Workers de domaine. |
+| Routes SDK de domaine | App runtime policy/events, Products offerings, Paywalls resolve/events, Analytics events/remote config, Onboardings resolve/events. |
+| `/api/v1/support-client/*`, `/api/v1/support/realtime/*` | Surface application Support authentifiée et ticket realtime. |
+| `/api/v1/app-files/*` et domaine Files | Alias de fichiers et téléchargement par ticket. |
+| `/api/v1/billing/*`, `/api/v2/purchases/*`, `/api/v1/iap/*` | Catalogue et clients historiques, achats v2, certifications, providers, refunds, exports et billing local/service. |
+| `/api/v1/platform/*` | Catalogue SDK, statut des Workers, compteurs, effacements, opérations Email et Custom. |
+| `/api/v1/mcp/*`, routes OAuth MCP | Consentement, tokens, projets, liens, analytics, campagnes et SDK config pour le MCP. |
+| `/api/v1/admin/*`, `/api/v1/automation/*`, `/api/v1/diagnostics/*` | Maintenance/cutover, automatisations historiques et diagnostics protégés. |
+| `/api/v1/marketing/tracking/*`, `/opt-in/*`, webhooks Marketing/Email | Entrées publiques signées ou vérifiées par provider. |
+| `/` et routes de short link | Résolution, assets et compatibilité des liens courts. |
+
+L’exécution de `npm run migration:inventory` sur le SHA a compté **320 routes Worker** et **120 tables D1**. Elle a aussi retourné `upstreamAvailable=false`, sans liste fiable de routes ou tables manquantes. Ce n’est pas un résultat de parité : le script et l’ADR refusent explicitement de traiter l’absence d’upstream comme un succès. [Sources : script][inventory-script], [tests fail-closed][inventory-tests], [ADR][adr-canonical].
+
+### 2.2 Contrats partagés et contrats encore locaux
+
+`@superboard/contracts` exporte dix familles : contexte projet signé, Email, Worker custom v2, Observability, santé SQL, secrets, lecture de body bornée, sécurité URL, dead letters et Analytics v1. `@superboard/email-transport` encapsule l’unique transport SMTP Worker-to-Worker. [Sources : manifeste][contracts-package], [exports][contracts-index], [transport Email][email-transport].
+
+Contrats structurants :
+
+- le contexte signé porte `projectId`, `projectRef`, `instanceId`, environnement, acteur, rôle, request ID, instant, module, méthode et pathname ; [source][project-context]
+- les erreurs de gateway de domaine ont une enveloppe stable avec `code`, `message`, `status`, `request_id`, `retryable` et `details` optionnel ; [source][domain-gateway]
+- le protocole Worker custom v2 expose manifest, stats et jobs idempotents avec les statuts `accepted`, `queued`, `dispatched`, `running`, `completed`, `failed`, `cancelled`, `rejected` ; [source][custom-contract]
+- Analytics v1 limite les batches, réserve le préfixe `superboard.`, normalise les identifiants/timestamps et sérialise de façon stable ; [source][analytics-contract]
+- Email sépare message métier, reçu, transport SMTP privé, événements provider sans destinataire, opérations body-free et dead letters ; [source][email-contract]
+- les secrets à rotation acceptent la valeur courante et l’éventuelle valeur `*_PREVIOUS`; les déploiements produisent des versions inactives puis une promotion liée aux IDs de rollback. [Sources : registre][service-registry], [readiness][platform-readiness-script].
+
+Écart important : au SHA, les contrats Products, Paywalls, Onboardings, Support et Marketing sont surtout définis dans les Workers et les services Dashboard, pas dans le package partagé. Les fichiers `packages/contracts/src/support.ts`, `support-notifications.ts` et `flows.ts` n’existent que dans le checkout non validé. Une migration de renderer sans gel de ces shapes risquerait de transformer des types locaux en API implicite.
+
+### 2.3 Headers et compatibilité client
+
+Le gateway accepte encore plusieurs familles de headers : `Authorization`, `X-Api-Key`, `PROJECT-KEY`, `PLATFORM`, `IDENTIFIER`, `ENVIRONMENT`, les variantes `X-OpenGrow-*` et `X-SuperBoard-*`, `Idempotency-Key`, les headers de diagnostics et les headers du contexte interne. L’auth SDK distingue trois modes : mobile par `PROJECT-KEY` + plateforme/identifiant, serveur par `PROJECT-KEY` + environnement, et legacy par `X-Api-Key`. [Sources : CORS et montage][api-index], [middleware SDK][api-auth-middleware].
+
+Ces aliases sont des contrats de compatibilité, même quand leur nom est historique. Les supprimer au profit d’un schéma EmDash unique casserait les clients existants ; ils doivent rester au gateway ou être versionnés avec une migration séparée.
+
+## 3. Modules, Workers, traitements asynchrones et stockages
+
+### 3.1 Catalogue des services
+
+Le registre déclare 8 services de domaine et 10 rôles de plateforme, soit 18 rôles logiques avant les Workers managés propres à une application. `configuration:check` a validé 17 services actifs pour chacun des targets actuels, car Messaging ou Analytics peut être désactivé et les orchestrateurs managés ne sont pas des clés du registre de base. [Sources : registre][service-registry], [catalogue opérateur][platform-status-route], [targets][target-schema].
+
+| Service | Surface et données possédées | État au SHA |
+| --- | --- | --- |
+| Dashboard | Back-office Next/OpenNext, cache OpenNext target-scoped. | **Livré** sur les deux manifests. [source][dashboard-package] |
+| API | Gateway, OAuth Dashboard/MCP, instances/projets, compatibilité SDK, notifications, orchestration, maintenance et D1 central/KV/R2. | **Livré** ; 60 migrations centrales jusqu’à `0060_analytics_verified_fact_backfill.sql`. [source][api-migrations] |
+| App | Customers, referrals, access key, setup plateforme, runtime policy et customer events ; D1 App. | **Livré**, activé sur les deux targets. [source][app-worker] |
+| Products | Produits, packages, offerings, entitlements, achats/refunds/subscriptions et catalog sync ; D1 Products. | **Livré**, activé sur les deux targets. [source][products-worker] |
+| Paywalls | Paywalls/versioning, placements, résolution, expériences/variants et événements ; D1 Paywalls. | **Livré**, activé sur les deux targets. [source][paywalls-worker] |
+| Dynamic Links | Liens, campagnes, règles, domaines, social preview, tracking et statistiques ; D1 Dynamic Links. | **Livré**, activé sur les deux targets. [source][dynamic-links-worker] |
+| Support | Client app, inbox opérateur, contacts, sociétés, notes, participants, drafts, CSAT, config, realtime, attachments et webhooks ; D1/R2/Queue/DLQ/DO. | **Livré en source ; partiel en production** tant que Chatwoot/OpenChat, les données et ressources legacy restent nécessaires. [sources][openchat-convergence] |
+| Analytics | Ingestion, events, sessions, profils, applications, dashboards/widgets, views, dimensions, crashes, feedback, remote config, cohorts, alerts, hooks, annotations, funnels, retention, reports et opérations ; D1/R2/Queue/Workflow. | **Livré MBZA ; désactivé VocoStar.** [source][analytics-worker] |
+| Marketing | Consentement, subscribers, listes, segments, templates/media, campagnes, transactional, journeys/signals/connectors, SMTP, provider events, outbox et DLQ ; D1/R2/Queue. | **Livré**, activé sur les deux targets. [source][marketing-worker] |
+| Onboardings | Définitions, versions, placements, targeting, expériences, résolution/events et statistiques ; D1. | **Livré**, activé sur les deux targets. [source][onboardings-worker] |
+| Billing | Autorité achats/entitlements/providers, projections, certifications et jobs ; D1 central, KV/R2, Queue et binding Analytics. | **Livré en source.** MBZA est déclaré `local`, VocoStar `service`; la certification provider/appareil reste un gate externe. [sources : Worker][billing-worker], [cutover][billing-cutover] |
+| Identity | Melody Auth intégré, utilisateurs application, email/password, providers, refresh, profile, reset, logs et admin proxifié ; D1 Identity, assets, Email et Files bindings. | **Livré en source**, SSO target désactivé. [source][identity-worker] |
+| Files | Upload/list/download/delete, metadata, tickets, effacement ; D1 Files + R2 principal. | **Livré**. [source][files-worker] |
+| Email | Capture/preview ou SMTP, AWS SES, idempotence, opérations et dead letters ; D1 Email + Queue/DLQ. | **Livré**. [source][email-worker] |
+| Observability | Lecture bornée d’Analytics Engine et résumé d’invocations/CPU/wall time. | **Livré**, sans D1 propre. [source][observability-worker] |
+| MCP | Worker public stateless lié en privé à l’API ; adapter local, serveur stdio/HTTP et catalogue d’outils dans `apps/mcp`. | **Livré**. [sources : Worker][mcp-worker], [app MCP][mcp-app] |
+| Messaging | Ancien inbox/conversations/realtime avec D1/R2/Queue/DO. | **Historique**, `features.messaging=false` sur les deux targets ; conservé pour lecture/migration/rollback. [source][messaging-architecture] |
+| Custom reference | `reference.echo` et reçu d’acceptance, D1 durable, cron de rétention. | **Livré** pour MBZA development. [source][custom-reference] |
+| Custom VocoStar | Jobs voix/média, annulation/retry, D1 VocoStar et bindings vers Files et orchestrateurs. | **Partiel/bloqué** : le runtime bridge est `blocked`. [sources : Worker][custom-vocostar], [target][target-vocostar] |
+| Orchestrateurs VocoStar | Workflows vocaux/médias, Durable Objects Dispatcher, pools Containers Standard/Premium et R2 legacy. | **Présents mais bloqués pour activation** par les routes Files/callbacks legacy. [sources : vocals][vocals-orchestrator], [medias][medias-orchestrator] |
+
+### 3.2 Traitements asynchrones
+
+| Producteur/consommateur | Traitements et garanties visibles |
+| --- | --- |
+| API | Cron : drain de l’outbox de faits Analytics, reprise des effacements de compte, refresh Apple notifications et maintenance. Queues : events, push, maintenance et Billing selon le mode. Les DLQ sont mises en quarantaine avant ack. [source][api-index] |
+| Billing | Cron de réconciliation ; Queue Billing en mode service ou local ; DLQ persistée, replay/discard audité et idempotence financière. [sources][billing-worker] |
+| Email | Queue de livraison avec idempotence, retry, événements de transport et quarantaine DLQ. Le Worker est l’unique autorité de socket SMTP. [sources : Worker][email-worker], [contrat][email-contract] |
+| Support | Queue + DLQ pour webhooks/événements, D1 de livraison, R2 attachments et un `ConversationRoom` Durable Object par conversation pour séquence et WebSocket hibernant. [sources : registre][service-registry], [architecture][messaging-architecture] |
+| Analytics | Queue d’ingestion, cron chaque minute, archive R2 et `AnalyticsOperationsWorkflow` pour export, replay, rebuild de rollups et effacement de sujet avec retries bornés. [sources : registre][service-registry], [Workflow][analytics-operations] |
+| Marketing | Queue de delivery, cron chaque minute, outbox/double opt-in, journeys, retry et quarantaine ; délègue le transport à Email. [sources : registre][service-registry], [Worker][marketing-worker] |
+| Custom reference | Cron quotidien et D1 de jobs/acceptance. [source][custom-reference] |
+| Custom VocoStar | Cron chaque minute pour dispatch/reprise ; deux Workflows Cloudflare pilotent Durable Objects et Containers, avec leases et tentatives bornées. [sources : target][target-vocostar], [orchestrateurs][vocals-orchestrator] |
+| Services synchrones | App, Products, Paywalls, Dynamic Links et Onboardings possèdent un D1 mais aucun Queue/cron propre au registre. Files et Identity sont synchrones ; Observability lit Analytics Engine ; MCP appelle l’API par Service Binding. [source][service-registry] |
+
+### 3.3 Chaînes de migrations D1
+
+Le nom de fichier est une partie du contrat Cloudflare. Les chaînes suivantes existent au SHA :
+
+| Propriétaire | Nombre | Dernière migration |
+| --- | ---: | --- |
+| API central | 60 | `0060_analytics_verified_fact_backfill.sql` [source][api-migrations] |
+| Identity | 51 | `0149_superboard_identity_log_scope.sql` [source][identity-migrations] |
+| Email | 7 | `0007_aws_ses_events.sql` [source][email-migrations] |
+| Files | 1 | `0001_files.sql` [source][files-migrations] |
+| Messaging historique | 4 | `0004_messaging_dead_letters.sql` [source][messaging-migrations] |
+| App | 4 | `0004_sdk_secret_references.sql` [source][app-migrations] |
+| Products | 3 | `0003_audit_context.sql` [source][products-migrations] |
+| Paywalls | 3 | `0003_audit_context.sql` [source][paywalls-migrations] |
+| Dynamic Links | 3 | `0003_campaign_analytics.sql` [source][dynamic-links-migrations] |
+| Support | 10 | `0009_application_user_erasure.sql` (la chaîne contient aussi `0002a_support_base_upgrade.sql`) [source][support-migrations] |
+| Analytics | 2 | `0002_countly_capabilities.sql` [source][analytics-migrations] |
+| Marketing | 11 | `0011_marketing_journeys.sql` [source][marketing-migrations] |
+| Onboardings | 3 | `0003_full_onboardings.sql` [source][onboardings-migrations] |
+| Custom reference | 2 | `0002_reference_acceptance.sql` [source][custom-reference-migrations] |
+| Custom VocoStar | 4 | `0004_owner_scoped_file_ids.sql` [source][custom-vocostar-migrations] |
+
+Billing ne possède pas de répertoire de migrations indépendant : son Worker utilise la base centrale et ses tables/migrations vivent dans la chaîne API. Observability, MCP et Dashboard n’ont pas de D1 métier propre ; le Dashboard a un KV de cache OpenNext target-scoped. [Sources : types Billing][billing-types], [registre D1][d1-registry].
+
+Une migration EmDash qui déplace seulement le contenu visuel ne doit pas déplacer l’autorité de ces données dans le CMS. Les drafts/releases EmDash doivent référencer les capacités ; les migrations et écritures métier restent chez leurs propriétaires actuels jusqu’à une décision explicite différente.
+
+## 4. SDK, catalogues et consommateurs
+
+### 4.1 Catalogue de release canonique
+
+Le catalogue machine-validé contient 7 entrées. Son état est : [source][sdk-catalog].
+
+| Entrée | Lifecycle | Source au SHA | Baseline immuable | État |
+| --- | --- | --- | --- | --- |
+| Flutter | active | `superboard_flutter` candidat 3.0.0 dans `sdks/flutter` | `opengrow_flutter` 2.1.4, `sdk-flutter-v2.1.4` | **Partiel : pending-release** |
+| FlutterFlow | active | `superboard_flutterflow` candidat 3.0.0 | `opengrow_flutterflow` 2.2.5, `sdk-flutterflow-v2.2.5` | **Partiel : pending-release** |
+| FlutterFlow Support | archived | 1.3.0 gelé | `sdk-flutterflow-messaging-v1.3.0` | **Historique/released** |
+| iOS | internal | 1.0.3 | tag/release 1.0.3 | **Interne/released** |
+| Android | internal | 1.0.3 | `sdk-android-v1.0.3` | **Interne/released** |
+| JavaScript | archived | 1.0.2 | `sdk-js-v1.0.2` | **Historique/released** |
+| React Native | archived | 1.0.2 | `sdk-react-native-v1.0.2` | **Historique/released** |
+
+Le catalogue affirme explicitement que seules les deux bibliothèques Dart sont actives, que iOS/Android sont des implémentations internes de Flutter, et que JavaScript/React Native/Support standalone restent reproductibles sans nouvelles releases. La promotion de Flutter et FlutterFlow 3.0 est atomique. [Sources : catalogue][sdk-catalog], [contrat Reference][reference-sdk-coverage].
+
+### 4.2 FlutterFlow et application de référence
+
+Le manifeste FlutterFlow décrit 11 Library Values, 64 actions, 5 widgets et 3 pages. Il couvre bootstrap, Identity, runtime App, Analytics/links, purchases, Files, custom jobs et Support. [Sources : manifeste][flutterflow-library], [gate][flutterflow-library-script].
+
+L’application `apps/reference` matérialise 16 parcours : bootstrap, auth, création de compte, reset, home, profile, notifications, Files, Products, Paywall, Dynamic Links, Support, Marketing consent, Onboarding, Custom extension et Diagnostics. Elle compile volontairement les tags OpenGrow publiés, pas le candidat 3.0 non publié. [Sources : baseline][reference-baseline], [projet][reference-project], [tests][reference-tests].
+
+État **partiel** au SHA : `platform:readiness` signale une incohérence `flutterflow_source_version` entre le contrat Reference et le catalogue candidat, et deux releases actives en attente. La Reference reste donc un consommateur de rollback utile, mais pas encore la preuve d’un frontend SuperBoard 3.0 entièrement promu. [Sources : readiness][platform-readiness-script], [catalogue][sdk-catalog].
+
+### 4.3 Autres consommateurs
+
+- la famille Identity conserve cinq SDK Melody : Web, React, Vue, Angular et Next.js. Ils ciblent le même Worker Identity, utilisent OAuth code + PKCE et sont testés par `identity-sdks:check`, mais ils ne figurent pas dans le catalogue de release SuperBoard à 7 entrées. Leur politique de publication/compatibilité est donc une lacune à clarifier avant EmDash ; [sources : README][identity-sdks], [packages][identity-sdk-tree]
+- `apps/mcp` est un serveur/adaptateur local tandis que `workers/mcp` est le Worker distant stateless lié à l’API ; les deux consomment le même contrat opérateur ; [sources : app][mcp-app], [Worker][mcp-worker]
+- VocoStar est déclaré comme unique application FlutterFlow externe. Son plan compte 7 phases, 10 work items, 35 checks et 36 symboles de remplacement, mais sa source n’est pas dans le dépôt ; le readiness offline la marque `source-not-inspected`. [Sources : application][flutterflow-applications], [plan][flutterflow-vocostar-plan]
+- les anciens repos `superboard-platform` et `superboard-reference` sont déclarés legacy ; l’autorité est le monorepo actuel. [Sources : gouvernance][platform-governance], [provenance][history-migration].
+
+## 5. Targets, domaines et ressources Cloudflare
+
+### 5.1 Topologie déclarée
+
+| Dimension | `mbza-development / development` | `vocostar / production` |
+| --- | --- | --- |
+| Identité physique | `superboard`, stratégie canonique | logique `superboard`, physique `opengrow`, conservation du nom legacy |
+| Routage public | `active` | `staged` — Workers privés, routes publiques désactivées |
+| Features | Billing, App, Products, Paywalls, Dynamic Links, Support, Analytics, Marketing, Onboardings ; Messaging false | Les mêmes sauf Analytics false ; Messaging false |
+| Mode Billing | `local` | `service` |
+| Worker custom | Reference, D1, cron quotidien | VocoStar + deux Workers managés, D1/R2, Workflows, DO, Containers, cron chaque minute |
+| IDs de ressources | 14 requis/configurés selon le gate offline | 13 requis/configurés selon le gate offline ; slot Analytics D1 nul car désactivé |
+| Plan de déploiement calculé | 17 services, aucun blocker | 18 services incluant 2 orchestrateurs ; 3 blockers runtime bridge |
+| Client acceptance | Reference activée par la matrice | Pas de reference acceptance ; convergence FlutterFlow externe requise |
+
+[Sources : target MBZA][target-mbza], [target VocoStar][target-vocostar], [registre][service-registry], [matrice][deployment-matrix].
+
+### 5.2 Domaines publics
+
+| Surface | MBZA development | VocoStar production |
+| --- | --- | --- |
+| API | `api.mbza.dev` | `api.vocostar.com` |
+| Auth | `auth.mbza.dev` | `auth.vocostar.com` |
+| Short links | `in.mbza.dev` | `go.vocostar.com` |
+| SDK | `sdk.mbza.dev` | `sdk.vocostar.com` |
+| Dashboard | `board.mbza.dev` | `grow.vocostar.com` |
+| Files | `files.mbza.dev` | `files.vocostar.com` |
+| MCP | `mcp.mbza.dev` | `mcp.vocostar.com` |
+| Mail/Messaging legacy | `mail.mbza.dev` preview | `messages.vocostar.com` historique |
+
+Le target MBZA déclare aussi `grow.mbza.dev` comme domaine retiré qui doit rester non assigné. VocoStar surveille `chat.vocostar.com/ready` uniquement comme source legacy Chatwoot/OpenChat jusqu’à la migration et la rétention. [Sources : MBZA][target-mbza], [VocoStar][target-vocostar].
+
+### 5.3 Ressources à ne pas confondre avec le CMS
+
+Les deux manifests possèdent : D1 central, KV central, R2 central, cache Dashboard, D1 Email/Identity/Files/Custom, D1 par module, R2 Support/Analytics/Marketing, Queues et DLQ centrales et par module, dataset Analytics Engine, IDs de projets Support et paramètres publics d’application. VocoStar conserve en plus le D1/R2 Messaging legacy et le R2 custom `app-vocostar`. [Sources : manifests][targets-tree], [schéma][target-schema].
+
+Les IDs et noms de ressources sont une frontière de compatibilité. Le bootstrap adopte seulement une ressource au nom et au compte attendus, bloque les drifts et ne remplace pas silencieusement une base existante. EmDash ne doit jamais devenir une seconde registry physique ni générer des IDs Cloudflare indépendamment des targets. [Sources : bootstrap][bootstrap-script], [limites de configuration][configuration-boundaries].
+
+## 6. Déploiement, sauvegarde, rollback et gates
+
+### 6.1 Autorités de déploiement
+
+La matrice versionnée utilise deux autorités, chacune exclusive pour son target :
+
+- `dev` → `mbza-development` par **Cloudflare Workers Builds**, un build par service, sans builds de branches non production ;
+- `main` → `vocostar-production` par **GitHub Actions**, après succès de `CI` et dans l’environnement protégé `production`.
+
+[Sources : matrice][deployment-matrix], [documentation opérationnelle][cloudflare-doc], [tests de policy][backoffice-policy].
+
+Il existe une dérive documentaire : `docs/IMPLEMENTATION_AUDIT_2026-08-08.md` affirme que GitHub Actions est l’unique autorité et que Workers Builds a été retiré, alors que la matrice, `docs/CLOUDFLARE.md`, `docs/DEVELOPMENT_WORKFLOW.md` et les tests imposent encore Workers Builds en développement. Pour toute décision EmDash, les manifestes et tests opérationnels doivent primer sur cette phrase obsolète. [Sources : phrase contradictoire][implementation-audit], [matrice][deployment-matrix].
+
+Autre dérive : le README référence `packages/shared`, mais aucun path `packages/shared` n’existe au SHA ; seuls `packages/contracts` et `packages/email-transport` sont présents. [Sources : README][readme], [tree packages][packages-tree].
+
+### 6.2 CI et gates avant mutation
+
+La CI sélectionne les checks affectés et agrège un gate unique. Elle valide notamment : copy/catalogues, migrations, contrôle Cloudflare/GitHub, secrets scan, Workers, Dashboard OpenNext, SDK Dart, SDK historiques, SDK Identity, application Reference et sécurité non-Node. Les branches `dev` et `main` exigent le check `CI gate`, PR, CODEOWNERS et une approbation. [Sources : workflow CI][ci-workflow], [control plane GitHub][github-control-plane].
+
+Limite opérationnelle : les protections des environnements `development`, `production` et `sdk-release` sont encore `pending-external`; production et SDK release attendent notamment un second reviewer de confiance. [Source][github-control-plane].
+
+Pour la production, le workflow :
+
+1. refuse une révision superseded et résout la matrice au SHA exact ;
+2. valide targets, types générés, ordre, code et Worker custom ;
+3. applique le gate de routage public et vérifie domaines et **noms** de secrets sans afficher les valeurs ;
+4. valide la clé de chiffrement des backups ;
+5. charge des versions preflight isolées sans routes/crons/consumers ;
+6. sauvegarde et migre toutes les bases avant de déployer les Workers ;
+7. chiffre les SQL/receipts et conserve l’artefact 30 jours, y compris les artefacts récupérables après échec.
+
+[Source : workflow][deploy-workflow].
+
+### 6.3 Sauvegarde et convergence D1
+
+Un déploiement production complet ne peut pas utiliser `--skip-backup` ou `--skip-migrations`. Le plan sauvegarde tous les propriétaires de schéma avant la première écriture, vérifie taille et SHA-256 de chaque export, migre toutes les bases, écrit un receipt batch mode `0600`, vérifie le cutover Identity, puis seulement déploie dans l’ordre : Observability, Email, Files, Identity, domaines activés, Billing/Messaging éventuel, Workers managés, Custom, API, MCP, Dashboard. [Sources : plan][deploy-plan], [converger][d1-converge], [backup][d1-backup], [batch receipt][migration-batch].
+
+Le plan calculé au SHA donne :
+
+- MBZA development : 17 services, convergence par service, aucun blocker structurel ;
+- VocoStar production : 18 services, 12 propriétaires D1 dans le batch, puis Identity et Workers, mais trois blockers — runtime bridge non vérifié, Files input routing inactif et callbacks encore possédés par `api-auth-gateway`.
+
+[Sources : algorithme][deploy-plan], [target VocoStar][target-vocostar].
+
+Le gate de routage retourne actuellement `active-development` pour MBZA et `staged-private-workers` pour VocoStar. `staged` est un succès de sécurité, pas une preuve de bascule : aucune route publique de production ne doit être attachée et aucun reçu client n’est vérifié. [Sources : gate][routing-gate], [runbook][public-routing].
+
+### 6.4 Rollback réellement disponible
+
+Les mécanismes existants ne forment pas une transaction globale automatique :
+
+- rollback de trafic : remettre le propriétaire/version Worker précédents et repasser `publicRouting` à `staged` dans une révision reviewée ; [source][public-routing]
+- rollback D1 : réservé à une corruption prouvée, après vérification du batch chiffré ; ne jamais écraser des écritures post-cutover sans reverse delta ; [sources][deployment-doc]
+- cutover de modules : maintenance read-only, checkpoints, checksums, reverse delta, preuve de replayabilité et plan de rollback ; le legacy reste 30 jours ; [source][module-cutover]
+- Billing : retour de `billingExecutionMode` à `local`, transfert confirmé du consumer vers API, sans modifier les événements immuables ni supprimer la Queue ; [source][billing-cutover]
+- rotations de secrets : receipts liés au compte et aux versions, consommateurs dual-token promus avant les producteurs, récupération en ordre inverse ; [source][secret-management]
+- le loop général de `cloudflare-deploy-all` s’arrête au premier échec mais ne restaure pas automatiquement les Workers déjà déployés. Les versions et backups rendent la récupération possible ; l’opération reste orchestrée par le runbook. [Source][deploy-all].
+
+La migration EmDash doit donc ajouter son propre rollback atomique de **Release Front** sans prétendre rendre atomique le rollout multi-Worker. Le front doit pouvoir revenir à la release immuable précédente tandis que les Workers restent compatibles avec les deux releases pendant la fenêtre d’observation.
+
+## 7. Ce qui est effectivement incomplet au commit
+
+### 7.1 Bloqué ou partiel
+
+1. **VocoStar n’est pas publiquement basculé.** `publicRouting=staged`, pas de `productionCutover`, pas de client receipt ; le gateway public et le Dashboard historique restent des propriétaires à traiter pendant la bascule. [sources][target-vocostar]
+2. **Le pont custom voix/média est bloqué.** Files routing, callbacks `/internal/notify` et `/ws/*/progress`, et propriété du gateway ne correspondent pas encore au target. [sources][target-vocostar]
+3. **Analytics VocoStar est désactivé.** Les routes/pages existent mais ne doivent pas être présentées comme disponibles pour cette cible. [sources][target-vocostar]
+4. **Support/OpenChat n’est pas convergé.** Export, import, ressources dédiées, client FlutterFlow, acceptation, rollback, rétention et retrait restent à prouver. [source][openchat-convergence]
+5. **Les SDK Flutter/FlutterFlow 3.0 sont pending-release.** La Reference reste sur 2.x/1.3 et le readiness signale une incohérence de version source. [sources : catalogue][sdk-catalog], [Reference][reference-project]
+6. **La source FlutterFlow VocoStar n’est pas dans le dépôt.** Le plan est contracté mais la convergence réelle ne peut pas être inspectée sans un export frais. [source][flutterflow-vocostar-plan]
+7. **Les environnements GitHub de haute valeur attendent une protection externe.** [source][github-control-plane]
+8. **La parité historique n’est pas calculable.** Les chiffres 320/120 décrivent le présent, pas une équivalence à un upstream absent. [sources][adr-canonical]
+9. **Le contrat partagé ne couvre pas encore tous les domaines.** Les formes Support/Flows partagées observées localement ne sont pas livrées au SHA. [source][contracts-index]
+10. **La documentation contient au moins deux drifts** : autorité Workers Builds et répertoire `packages/shared`. Ils imposent de lier les futures décisions aux manifestes/tests, pas à des résumés narratifs isolés.
+
+### 7.2 Historique à conserver pendant la migration
+
+- aliases OpenGrow dans les headers, noms de packages et modèles de données ;
+- Worker/D1/R2/Queue Messaging désactivés tant qu’un lecteur ou rollback en dépend ;
+- Chatwoot/OpenChat et son monitor jusqu’à fin de la preuve de Support ;
+- SDK FlutterFlow Support, JavaScript et React Native gelés ;
+- tags iOS/Android et tags OpenGrow 2.x utilisés par la Reference ;
+- anciennes routes API et SDK v1/v2 ;
+- anciens noms physiques `opengrow` sur VocoStar et historiques de migrations SQL.
+
+[Sources : historique][history-migration], [Messaging][messaging-architecture], [catalogue SDK][sdk-catalog], [target][target-vocostar].
+
+## 8. Checkout partagé non validé — ne pas traiter comme livré
+
+Au 29 août 2026, le checkout partagé comparé à `d1850233` contient **172 entrées tracked modifiées/supprimées** et **128 entrées untracked** dans `git status --porcelain` ; les répertoires untracked peuvent contenir plusieurs fichiers. Sur le périmètre produit suivi par le diff, 140 fichiers trackés représentent environ 13 527 insertions et 2 673 suppressions. Aucun de ces changements n’a été modifié par cette recherche.
+
+Les ensembles les plus structurants sont :
+
+| Ensemble local | Paths observés | Classification |
+| --- | --- | --- |
+| Flows | `workers/flows/`, `sdks/flows/`, `apps/dashboard/src/app/(protected)/flows/`, `apps/dashboard/src/api/flows/`, `packages/contracts/src/flows.ts`, migration API `0061_flows_legacy_cutover.sql`, scripts de sync/cutover | **Checkout non validé.** Verticale apparemment complète, totalement absente du SHA. |
+| Support étendu | nouvelles pages `automations`, `captain`, `channels`, `help-center`, `integrations`, `proactive-support`, `reports`, `settings`, `workforce`; migrations Support `0010` à `0023`; nouveaux contrats/SDK/tests/runtime | **Checkout non validé.** Ne pas l’inclure dans la parité livrée sans commit reviewé. |
+| Notifications Support et Email inbound | `support-notifications.*`, migration API `0062`, gateway Support, `workers/email/src/inbound.ts`, changements Push/Email | **Checkout non validé.** |
+| SDK | nouveaux clients Flutter Flows/Support, FlutterFlow Flows, typings/support JavaScript, changements de catalogue/release | **Checkout non validé.** |
+| Contrôle Cloudflare | modifications targets, schéma, services, bootstrap, secrets, D1, contrôle GitHub et readiness | **Checkout non validé.** Peut changer la topologie ; ne pas mélanger avec le baseline. |
+| Documentation de domaine et hooks | `CONTEXT*.md`, `docs/agents/`, `AGENTS.md`, Husky/lint-staged/Prettier | **Checkout non validé.** Ces fichiers expliquent le travail en cours, pas l’état livré du SHA. |
+
+Il faut prendre une décision explicite avant la conception finale EmDash : soit rebaser l’inventaire sur un futur commit reviewé contenant ces travaux, soit maintenir `d1850233` comme baseline et traiter Flows/Support étendu comme une migration parallèle. Mélanger les deux créerait une parité impossible à auditer.
+
+## 9. Obligations de préservation pour la migration EmDash
+
+La migration est compatible uniquement si elle prouve les invariants suivants :
+
+### Front et navigation
+
+- les 93 routes actuelles ont chacune une décision : renderer EmDash, route système hors CMS, alias/redirect conservé, ou retrait explicitement accepté ;
+- les 10 sections, 60 liens, routes de détail, sélecteur de target/projet et choix `production/test` restent adressables ;
+- Account, Infrastructure, Project Settings, auth BFF, MCP consent et preview ne disparaissent pas parce qu’ils ne sont pas des entrées de section ;
+- loading, empty, unavailable, degraded, misconfigured, disabled, not-found et error retry restent des états de première classe ;
+- une Release Front est validée puis publiée atomiquement, et la release précédente reste restorable sans mutation des données métier.
+
+### Auth, permissions et session
+
+- le nouveau Front conserve le flux Dashboard OAuth, OTP, refresh/revoke, invitation/reset, `backTo` et `/users/me` ;
+- toute décision de remplacer le `localStorage` par une session cookie doit inclure un bridge explicite, pas une coupure silencieuse ;
+- le CMS ne devient jamais l’autorité des rôles métier : `owner/admin/member`, `sdk/application/system` et les checks serveurs demeurent ;
+- les routes configurables dans EmDash ne peuvent pas contourner la garde de route, le contexte projet signé ou les checks `owner/admin` ;
+- l’admin EmDash et le Front SuperBoard doivent avoir des sessions et des audiences clairement séparées.
+
+### API et Workers
+
+- la surface calculée de 320 routes, les aliases historiques, les headers SDK, les versions v1/v2 et les enveloppes d’erreur sont gelés par tests de contrat avant bascule ;
+- `projectRef`, `production/test`, idempotence, maintenance read-only et signatures HMAC restent identiques pour les Workers ;
+- les renderers EmDash appellent le gateway ; ils ne parlent pas directement aux D1, aux bindings privés ni aux Workers de domaine ;
+- les huit domaines conservent leur ownership et leurs migrations ; les ressources ne sont pas copiées dans EmDash ;
+- Queues, DLQ, DO, Workflows, cron et opérations longues restent observables depuis Infrastructure, y compris les compteurs `null/unavailable` plutôt que de faux zéros.
+
+### SDK et consommateurs
+
+- les tags OpenGrow actuels restent le rollback client jusqu’à promotion réelle de Flutter/FlutterFlow 3.0 ;
+- le Front EmDash ne doit pas imposer une release SDK non publiée ;
+- la Reference et VocoStar doivent être testées séparément, car la première est dans le repo et la seconde dépend d’un export externe ;
+- la famille Identity Melody hors catalogue doit recevoir une décision de lifecycle ;
+- Support legacy, JavaScript et React Native restent reproductibles même s’ils n’obtiennent plus de nouvelles features.
+
+### Targets et opérations
+
+- EmDash consomme `deploy/targets/*` et le registre de services ; il ne les remplace pas ;
+- MBZA development et VocoStar production gardent leurs domaines, noms physiques, IDs et modes de routage ;
+- aucune nouvelle autorité de déploiement automatique ne s’ajoute à Workers Builds/GitHub Actions sans décision et tests ;
+- la publication du Front doit s’insérer après les gates CI, routing, domains, secrets et backup applicables ;
+- le rollback du Front doit être prouvé indépendamment du rollback Worker/D1 ;
+- VocoStar ne peut être déclaré migré tant que ses trois blockers runtime bridge, sa convergence FlutterFlow, Support et les preuves de rollback ne sont pas fermés.
+
+## 10. Risques prioritaires pour la carte Wayfinder
+
+| Priorité | Risque / décision révélée | Pourquoi cela bloque la suite |
+| --- | --- | --- |
+| P0 | Choisir le baseline entre `d1850233` et un futur commit intégrant Flows/Support étendu | La surface à migrer change fortement et le checkout actuel n’est pas auditable comme release. |
+| P0 | Définir le modèle de session Front SuperBoard vs EmDash Admin | Le Dashboard actuel est client-side/localStorage ; une session fusionnée pourrait exposer des privilèges admin CMS ou casser les refresh/backTo. |
+| P0 | Définir un registre versionné route/renderer/capacité/permission/target | Navigation et permissions sont aujourd’hui dispersées entre React, API et Workers. |
+| P0 | Geler les contrats non partagés et la surface API/SDK | Les contrats Support/Products/etc. sont locaux et 320 routes rendent une migration ad hoc risquée. |
+| P0 | Décider comment une Release Front est compilée, validée, publiée et rollbackée | EmDash ne fournit pas encore dans ce dépôt l’artefact atomique requis par la destination. |
+| P1 | Fermer ou isoler les travaux VocoStar déjà bloqués | Le nouveau front ne peut pas transformer un target `staged` et un runtime bridge bloqué en « production migrée ». |
+| P1 | Coordonner la promotion SDK 3.0 avec le front | La Reference compile le rollback 2.x ; changer le front et le SDK simultanément supprimerait une preuve de retour arrière. |
+| P1 | Unifier l’autorité documentaire de déploiement | Le résumé d’audit contredit les manifests/tests ; une troisième pipeline EmDash augmenterait le risque de double déploiement. |
+| P1 | Construire la matrice de rollback multi-couche | Le repo a de bons outils D1/secret/module, mais aucun rollback transactionnel global des Workers et du Front. |
+| P2 | Décider du lifecycle des SDK Identity Melody et des routes hors navigation | Ils sont réels mais ne figurent pas dans le catalogue/dashboard principal. |
+
+## 11. Vérifications exécutées dans le worktree isolé
+
+Les commandes suivantes ont été exécutées sur le SHA après `npm ci --ignore-scripts`. Elles n’ont effectué aucune opération distante ni mutation Cloudflare/GitHub :
+
+| Vérification | Résultat |
+| --- | --- |
+| `npm run migration:inventory` | succès ; 320 routes, 120 tables, upstream indisponible et non vérifié |
+| `npm run migration:inventory:test` | 8/8 tests réussis, dont schéma D1 frais et fail-closed upstream |
+| `npm run cloudflare:test:services` | 28/28 tests réussis, dont huit domaines, migrations attendues, configs privées, Support stateful, Analytics durable et policy Workers |
+| `npm run sdk:catalog:check` | succès ; 7 bibliothèques |
+| `npm run sdk:catalog:test` | 16/16 tests réussis, dont promotion atomique et lifecycle gelé |
+| `npm run configuration:check` | succès ; 1 240 fichiers runtime, 17 services logiques, 14 IDs et 17 Workers déclarés par target, zéro valeur de secret dans les configs |
+| `cloudflare:deploy:all --plan` MBZA | succès ; 17 services, aucun blocker |
+| `cloudflare:deploy:all --plan` VocoStar | plan calculé ; 18 services, 12 schémas, 3 blockers runtime bridge |
+| `cloudflare:routing:check` | MBZA `active-development`; VocoStar `staged-private-workers` |
+| `npm run platform:readiness` offline | commande réussie mais `ready=false` : releases SDK, Reference, client VocoStar, credentials absents du processus et branche de recherche empêchent un résultat global vert |
+
+Les scripts correspondants sont eux-mêmes versionnés et testés : [inventaire][inventory-script], [services][service-registry], [catalogue SDK][sdk-catalog-script], [configuration][configuration-boundaries-script], [readiness][platform-readiness-script], [plan][deploy-plan] et [routing][routing-gate]. Un readiness offline rouge n’est pas une preuve d’indisponibilité distante ; il indique seulement que toutes les preuves requises ne sont pas présentes dans ce worktree/processus.
+
+## Conclusion
+
+Le baseline préservable est désormais explicite : un shell Dashboard codé, 93 routes, un gateway de 320 routes et 120 tables, huit domaines isolés, des contrats de projet/session/idempotence, une topologie Cloudflare target-driven, des pipelines de données asynchrones, sept SDK catalogués plus cinq SDK Identity, deux consommateurs de référence de maturité différente et des runbooks de sauvegarde/rollback non atomiques à l’échelle globale.
+
+La voie EmDash ne doit commencer la construction qu’après cinq décisions : baseline commitée, modèle de session séparé, registre route/renderer/permission, contrat de Release Front atomique, et ordre de coexistence avec les travaux VocoStar/SDK/Support déjà incomplets. Sans ces décisions, « migrer toutes les pages » produirait une nouvelle interface mais perdrait le plan de contrôle que la destination exige de préserver.
+
+<!-- Permaliens de sources primaires, tous épinglés au commit de référence. -->
+
+[adr-canonical]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/ADR-001-CANONICAL-SUPERBOARD-SOURCE.md
+[analytics-contract]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/src/analytics.ts
+[analytics-http]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/analytics/src/http.ts
+[analytics-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/analytics/migrations
+[analytics-operations]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/analytics/src/operations.ts
+[analytics-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/analytics/src/index.ts
+[api-auth]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/lib/auth.ts
+[api-auth-middleware]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/middleware/auth.ts
+[api-index]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/index.ts
+[api-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/migrations
+[api-routes-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/routes
+[app-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/app/migrations
+[app-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/app/src/index.ts
+[architecture]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/ARCHITECTURE_CIBLE_FR.md
+[auth-refresh-route]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/api/auth/refresh/route.ts
+[auth-revoke-route]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/api/auth/revoke/route.ts
+[auth-token-route]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/api/auth/token/route.ts
+[backoffice-policy]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/backoffice-policy.test.mjs
+[billing-cutover]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/BILLING_WORKER_CUTOVER.md
+[billing-routes]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/routes
+[billing-types]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/types.ts
+[billing-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/billing/src/index.ts
+[bootstrap-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-bootstrap.mjs
+[ci-workflow]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/.github/workflows/ci.yml
+[cloudflare-doc]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/CLOUDFLARE.md
+[configuration-boundaries]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/configuration-boundaries.json
+[configuration-boundaries-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/configuration-boundaries.mjs
+[contracts-index]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/src/index.ts
+[contracts-package]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/package.json
+[custom-contract]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/src/custom-worker.ts
+[custom-reference]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/reference/src/index.ts
+[custom-reference-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/reference/migrations
+[custom-vocostar]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/vocostar/src/index.ts
+[custom-vocostar-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/vocostar/migrations
+[d1-backup]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-backup.mjs
+[d1-converge]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-converge.mjs
+[d1-registry]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-d1-registry.mjs
+[dashboard-admin-only]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/lib/adminOnlyDisplay.tsx
+[dashboard-analytics-pages]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/analytics/AnalyticsPages.tsx
+[dashboard-api-client]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/lib/api.ts
+[dashboard-api-routes]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/api
+[dashboard-app-api]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/api/app
+[dashboard-app-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app
+[dashboard-client-layout]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/ClientLayout.tsx
+[dashboard-cloudflare]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/dashboard-cloudflare.mjs
+[dashboard-global-error]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/global-error.tsx
+[dashboard-header]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/layout/app-header.tsx
+[dashboard-identity-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/identity
+[dashboard-instance-types]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/types/instance.ts
+[dashboard-marketing-pages]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/modules/MarketingPages.tsx
+[dashboard-mcp-authorize]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/mcp/authorize/page.tsx
+[dashboard-message-preview]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/message-preview-craft/page.tsx
+[dashboard-navigation]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/config/navigation.ts
+[dashboard-next]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/next.config.ts
+[dashboard-not-found]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/not-found.tsx
+[dashboard-onboarding-pages]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/modules/OnboardingPages.tsx
+[dashboard-package]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/package.json
+[dashboard-paywalls-page]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/modules/PaywallsPage.tsx
+[dashboard-products-pages]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/modules/ProductsPages.tsx
+[dashboard-project-context]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/context/useProjectSelection.tsx
+[dashboard-protected-error]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/error.tsx
+[dashboard-protected-layout]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/layout.tsx
+[dashboard-protected-loading]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/%28protected%29/loading.tsx
+[dashboard-refresh]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/lib/RefreshTokenHelper.ts
+[dashboard-root-layout]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/layout.tsx
+[dashboard-root-page]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/app/page.tsx
+[dashboard-sdk-wizard]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/app/SdkSetupWizard.tsx
+[dashboard-section-nav]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/layout/section-navigation.tsx
+[dashboard-sidebar]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/layout/app-sidebar.tsx
+[dashboard-user-context]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/context/useUserContext.tsx
+[dashboard-user-nav]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/components/layout/nav-user.tsx
+[dashboard-user-service]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/api/auth/userService.ts
+[deploy-all]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-deploy-all.mjs
+[deploy-plan]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-deploy-plan.mjs
+[deploy-workflow]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/.github/workflows/deploy-cloudflare.yml
+[deployment-doc]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/DEPLOYMENT.md
+[deployment-matrix]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/cloudflare-deployments.json
+[domain-gateway]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/lib/domain-modules.ts
+[dynamic-links-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/dynamic-links/migrations
+[dynamic-links-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/dynamic-links/src/index.ts
+[email-contract]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/src/email.ts
+[email-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/email/migrations
+[email-transport]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/email-transport/src/index.ts
+[email-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/email/src/index.ts
+[files-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/files/migrations
+[files-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/files/src/index.ts
+[flutterflow-applications]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/flutterflow-applications.json
+[flutterflow-library]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/flutterflow-library.json
+[flutterflow-library-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/flutterflow-library-contract.mjs
+[flutterflow-vocostar-plan]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/flutterflow-migrations/vocostar.json
+[github-control-plane]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/github-control-plane.json
+[history-migration]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/HISTORY_MIGRATION.md
+[identity-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/identity/migrations
+[identity-sdk-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/sdks/identity
+[identity-sdks]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/sdks/identity/README.md
+[identity-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/identity/src/index.ts
+[implementation-audit]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/IMPLEMENTATION_AUDIT_2026-08-08.md
+[inventory-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/superboard-inventory.mjs
+[inventory-tests]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/superboard-inventory.test.mjs
+[local-storage]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/lib/LocalStorage.ts
+[marketing-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/marketing/migrations
+[marketing-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/marketing/src/index.ts
+[mcp-app]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/mcp
+[mcp-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/mcp/src/index.ts
+[medias-orchestrator]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/vocostar/orchestrators/medias/src/index.ts
+[messaging-architecture]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/MESSAGING_ARCHITECTURE.md
+[messaging-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/messaging/migrations
+[migration-batch]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-migration-batch.mjs
+[module-cutover]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/MODULE_CUTOVER_RUNBOOK.md
+[observability-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/observability/src/index.ts
+[onboardings-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/onboardings/migrations
+[onboardings-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/onboardings/src/index.ts
+[openchat-convergence]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/OPENCHAT_SUPPORT_CONVERGENCE.md
+[packages-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages
+[paywalls-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/paywalls/migrations
+[paywalls-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/paywalls/src/index.ts
+[platform-governance]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/platform-governance.json
+[platform-readiness-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/platform-readiness.mjs
+[platform-status-route]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/api/src/routes/platform-status.ts
+[products-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/products/migrations
+[products-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/products/src/index.ts
+[project-context]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/packages/contracts/src/project-context.ts
+[protected-route]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/dashboard/src/lib/ProtectedRoute.tsx
+[public-routing]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/PUBLIC_ROUTING_CUTOVER.md
+[readme]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/README.md
+[reference-baseline]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/reference/docs/BASELINE.md
+[reference-project]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/reference/reference.project.json
+[reference-sdk-coverage]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/reference/docs/SDK_COVERAGE.md
+[reference-tests]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/apps/reference/test
+[routing-gate]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/public-routing-gate.mjs
+[sdk-catalog]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/config/sdk-libraries.json
+[sdk-catalog-script]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/sdk-catalog.mjs
+[secret-management]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/docs/SECRET_MANAGEMENT.md
+[service-registry]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/scripts/cloudflare-services.mjs
+[support-migrations]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/support/migrations
+[support-worker]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/support/src/index.ts
+[target-mbza]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/mbza-development.json
+[target-schema]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/schema.json
+[target-vocostar]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets/vocostar.json
+[targets-tree]: https://github.com/mabzadev/superboard/tree/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/deploy/targets
+[vocals-orchestrator]: https://github.com/mabzadev/superboard/blob/d1850233e97b79c3cde7eae18a0123d4d39c8ae2/workers/custom/vocostar/orchestrators/vocals/src/index.ts

--- a/workers/CONTEXT.md
+++ b/workers/CONTEXT.md
@@ -1,0 +1,13 @@
+# Workers SuperBoard
+
+Ce contexte définit la place des runtimes métier dans le Site EmDash cible.
+
+## Langage
+
+**Worker métier** :
+Runtime Cloudflare qui conserve les traitements et données opérationnels d’un plugin module SuperBoard.
+_À éviter_ : plugin full EmDash, page EmDash
+
+**Donnée opérationnelle** :
+Donnée produite ou consommée par l’exécution métier d’un module et qui reste sous la responsabilité de son Worker.
+_À éviter_ : contenu éditorial, Release Front


### PR DESCRIPTION
## Résumé

- ajoute l’audit des capacités et limites d’EmDash ;
- ajoute l’inventaire de la surface et des contrats actuels de SuperBoard ;
- ajoute l’audit de compatibilité entre EmDash et la topologie Cloudflare SuperBoard ;
- ajoute le vocabulaire multi-contexte de la migration ;
- ne modifie aucun code produit, Worker, SDK, manifeste ou déploiement.

Carte de suivi : [Migration complète de SuperBoard vers EmDash CMS](https://github.com/mabzadev/superboard/issues/33).

## Vérifications

- historique de la branche linéaire, sans merge commit ;
- `git diff --check origin/dev..HEAD` ;
- hook pré-commit du dépôt exécuté avec succès sur les mêmes contenus avant reconstruction linéaire ;
- les trois rapports citent des sources primaires immuables.