### PR TITLE
feat: rendre le lifecycle des plugins data-driven

### DIFF
--- a/.changeset/explicit-plugin-activation.md
+++ b/.changeset/explicit-plugin-activation.md
@@ -2,6 +2,6 @@
 "emdash": minor
 ---
 
-Adds `defaultEnabled` to plugin descriptors. Set it to `false` for a statically configured sandboxed plugin that should appear in the plugin catalog but remain inactive until an administrator enables it or persisted lifecycle state marks it active.
+Adds `defaultEnabled` and `lifecycleManaged` to plugin descriptors. Set `defaultEnabled: false` for a statically configured sandboxed plugin that should appear in the plugin catalog but remain inactive until persisted lifecycle state marks it active. Set `lifecycleManaged: true` when a host workflow must reject the generic enable and disable actions in **Plugins**.
 
 The default remains `true`, so existing plugin configurations keep their current activation behavior.

--- a/.changeset/explicit-plugin-activation.md
+++ b/.changeset/explicit-plugin-activation.md
@@ -4,4 +4,4 @@
 
 Adds `defaultEnabled` and `lifecycleManaged` to plugin descriptors. Set `defaultEnabled: false` for a statically configured sandboxed plugin that should appear in the plugin catalog but remain inactive until persisted lifecycle state marks it active. Set `lifecycleManaged: true` when a host workflow must reject the generic enable and disable actions in **Plugins**.
 
-The default remains `true`, so existing plugin configurations keep their current activation behavior.
+`defaultEnabled` remains `true` and `lifecycleManaged` defaults to `false`, so existing plugin configurations keep their current activation behavior.

--- a/.changeset/explicit-plugin-activation.md
+++ b/.changeset/explicit-plugin-activation.md
@@ -1,0 +1,7 @@
+---
+"emdash": minor
+---
+
+Adds `defaultEnabled` to plugin descriptors. Set it to `false` for a statically configured sandboxed plugin that should appear in the plugin catalog but remain inactive until an administrator enables it or persisted lifecycle state marks it active.
+
+The default remains `true`, so existing plugin configurations keep their current activation behavior.

--- a/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
+++ b/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
@@ -167,3 +167,177 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_runtime_health (
 
 CREATE INDEX IF NOT EXISTS idx_plugin_runtime_health_ready
   ON superboard_plugin_runtime_health(instance_id, target, status, expires_at);
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_release_reconciliations (
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  release_id TEXT NOT NULL
+    REFERENCES superboard_front_release_candidates(release_id),
+  plugin_lock_json TEXT NOT NULL CHECK (json_valid(plugin_lock_json)),
+  status TEXT NOT NULL CHECK (status IN ('prepared', 'applied')),
+  prepared_at TEXT NOT NULL,
+  applied_at TEXT,
+  PRIMARY KEY (instance_id, target, release_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_release_reconciliations_release
+  ON superboard_plugin_release_reconciliations(release_id);
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_insert_guard
+BEFORE INSERT ON superboard_front_active_releases
+WHEN EXISTS (
+  SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+  WHERE lifecycle.instance_id = NEW.instance_id
+)
+AND NOT EXISTS (
+  SELECT 1 FROM superboard_plugin_release_reconciliations reconciliation
+  WHERE reconciliation.instance_id = NEW.instance_id
+    AND reconciliation.release_id = NEW.active_release_id
+    AND reconciliation.status = 'prepared'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle reconciliation is not prepared');
+END;
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_update_guard
+BEFORE UPDATE ON superboard_front_active_releases
+WHEN EXISTS (
+  SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+  WHERE lifecycle.instance_id = NEW.instance_id
+)
+AND NOT EXISTS (
+  SELECT 1 FROM superboard_plugin_release_reconciliations reconciliation
+  WHERE reconciliation.instance_id = NEW.instance_id
+    AND reconciliation.release_id = NEW.active_release_id
+    AND reconciliation.status = 'prepared'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle reconciliation is not prepared');
+END;
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_apply
+AFTER INSERT ON superboard_front_activations
+BEGIN
+  INSERT INTO superboard_plugin_lifecycle_events (
+    instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
+    plan_id, release_id, reason, changed_at
+  )
+  SELECT lifecycle.instance_id, lifecycle.target, lifecycle.plugin_id,
+         lifecycle.artifact_checksum, lifecycle.state,
+         CASE WHEN lifecycle.state = 'draining' THEN 'disabled' ELSE 'active' END,
+         lifecycle.plan_id, NEW.active_release_id, 'Front Release activation', NEW.activated_at
+  FROM superboard_plugin_lifecycle lifecycle
+  JOIN superboard_plugin_release_reconciliations reconciliation
+    ON reconciliation.instance_id = lifecycle.instance_id
+   AND reconciliation.target = lifecycle.target
+   AND reconciliation.release_id = NEW.active_release_id
+   AND reconciliation.status = 'prepared'
+  WHERE lifecycle.instance_id = NEW.instance_id
+    AND (
+      (lifecycle.state = 'installed' AND EXISTS (
+        SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+        WHERE json_extract(lock.value, '$.plugin_id') = lifecycle.plugin_id
+          AND json_extract(lock.value, '$.artifact_checksum') = lifecycle.artifact_checksum
+      ))
+      OR
+      (lifecycle.state = 'draining' AND NOT EXISTS (
+        SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+        WHERE json_extract(lock.value, '$.plugin_id') = lifecycle.plugin_id
+      ))
+    );
+
+  UPDATE superboard_plugin_lifecycle
+  SET state = CASE WHEN superboard_plugin_lifecycle.state = 'draining' THEN 'disabled' ELSE 'active' END,
+      activated_release_id = NEW.active_release_id,
+      state_changed_at = NEW.activated_at,
+      reason = 'Front Release activation'
+  WHERE superboard_plugin_lifecycle.instance_id = NEW.instance_id
+    AND EXISTS (
+      SELECT 1 FROM superboard_plugin_release_reconciliations reconciliation
+      WHERE reconciliation.instance_id = superboard_plugin_lifecycle.instance_id
+        AND reconciliation.target = superboard_plugin_lifecycle.target
+        AND reconciliation.release_id = NEW.active_release_id
+        AND reconciliation.status = 'prepared'
+        AND (
+          (superboard_plugin_lifecycle.state IN ('installed', 'active') AND EXISTS (
+            SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+            WHERE json_extract(lock.value, '$.plugin_id') = superboard_plugin_lifecycle.plugin_id
+              AND json_extract(lock.value, '$.artifact_checksum') = superboard_plugin_lifecycle.artifact_checksum
+          ))
+          OR
+          (superboard_plugin_lifecycle.state = 'draining' AND NOT EXISTS (
+            SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+            WHERE json_extract(lock.value, '$.plugin_id') = superboard_plugin_lifecycle.plugin_id
+          ))
+        )
+    );
+
+  UPDATE superboard_plugin_installation_items
+  SET state = 'active'
+  WHERE EXISTS (
+    SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+    WHERE lifecycle.plan_id = superboard_plugin_installation_items.plan_id
+      AND lifecycle.plugin_id = superboard_plugin_installation_items.plugin_id
+      AND lifecycle.state = 'active'
+      AND lifecycle.activated_release_id = NEW.active_release_id
+  );
+
+  UPDATE superboard_plugin_installation_plans
+  SET status = 'active', completed_at = NEW.activated_at
+  WHERE superboard_plugin_installation_plans.status = 'installed'
+    AND NOT EXISTS (
+      SELECT 1 FROM superboard_plugin_installation_items item
+      WHERE item.plan_id = superboard_plugin_installation_plans.plan_id AND item.state <> 'active'
+    );
+
+  INSERT INTO superboard_active_plugin_manifests
+    (plugin_id, artifact_checksum, activated_at)
+  SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, NEW.activated_at
+  FROM superboard_plugin_lifecycle lifecycle
+  JOIN superboard_plugin_release_reconciliations reconciliation
+    ON reconciliation.instance_id = lifecycle.instance_id
+   AND reconciliation.target = lifecycle.target
+   AND reconciliation.release_id = NEW.active_release_id
+  WHERE lifecycle.instance_id = NEW.instance_id
+    AND lifecycle.state = 'active'
+    AND lifecycle.activated_release_id = NEW.active_release_id
+  ON CONFLICT(plugin_id) DO UPDATE SET
+    artifact_checksum = excluded.artifact_checksum,
+    activated_at = excluded.activated_at;
+
+  DELETE FROM superboard_active_plugin_manifests
+  WHERE plugin_id IN (
+    SELECT lifecycle.plugin_id
+    FROM superboard_plugin_lifecycle lifecycle
+    JOIN superboard_plugin_release_reconciliations reconciliation
+      ON reconciliation.instance_id = lifecycle.instance_id
+     AND reconciliation.target = lifecycle.target
+     AND reconciliation.release_id = NEW.active_release_id
+    WHERE lifecycle.instance_id = NEW.instance_id
+      AND lifecycle.state IN ('disabled', 'quarantined', 'purged')
+  );
+
+  INSERT INTO superboard_dependency_health
+    (instance_id, dependency_id, status, evidence_checksum, checked_at, expires_at)
+  SELECT lifecycle.instance_id,
+         'dependency.' || replace(lifecycle.plugin_id, '-', '_'),
+         'ready', health.evidence_checksum, NEW.activated_at, health.expires_at
+  FROM superboard_plugin_lifecycle lifecycle
+  JOIN superboard_plugin_runtime_health health
+    ON health.instance_id = lifecycle.instance_id
+   AND health.target = lifecycle.target
+   AND health.plugin_id = lifecycle.plugin_id
+   AND health.artifact_checksum = lifecycle.artifact_checksum
+  WHERE lifecycle.instance_id = NEW.instance_id
+    AND lifecycle.state = 'active'
+    AND lifecycle.activated_release_id = NEW.active_release_id
+  ON CONFLICT(instance_id, dependency_id) DO UPDATE SET
+    status = 'ready', evidence_checksum = excluded.evidence_checksum,
+    checked_at = excluded.checked_at, expires_at = excluded.expires_at;
+
+  UPDATE superboard_plugin_release_reconciliations
+  SET status = 'applied', applied_at = NEW.activated_at
+  WHERE instance_id = NEW.instance_id
+    AND release_id = NEW.active_release_id
+    AND status = 'prepared';
+END;

--- a/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
+++ b/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
@@ -1,9 +1,22 @@
 PRAGMA foreign_keys = ON;
 
+CREATE TABLE IF NOT EXISTS superboard_plugin_target_artifacts (
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  artifact_checksum TEXT NOT NULL,
+  plugin_ids_json TEXT NOT NULL CHECK (json_valid(plugin_ids_json)),
+  registered_at TEXT NOT NULL,
+  PRIMARY KEY (instance_id, target)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_target_artifacts_checksum
+  ON superboard_plugin_target_artifacts(artifact_checksum);
+
 CREATE TABLE IF NOT EXISTS superboard_plugin_installation_plans (
   plan_id TEXT PRIMARY KEY,
   instance_id TEXT NOT NULL,
   target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  target_artifact_checksum TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('installing', 'installed', 'active', 'failed')),
   catalog_checksum TEXT NOT NULL,
   plugin_count INTEGER NOT NULL CHECK (plugin_count > 0),
@@ -173,6 +186,7 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_release_reconciliations (
   target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
   release_id TEXT NOT NULL
     REFERENCES superboard_front_release_candidates(release_id),
+  target_artifact_checksum TEXT NOT NULL,
   plugin_lock_json TEXT NOT NULL CHECK (json_valid(plugin_lock_json)),
   status TEXT NOT NULL CHECK (status IN ('prepared', 'applied')),
   prepared_at TEXT NOT NULL,
@@ -223,6 +237,13 @@ WHEN EXISTS (
     AND reconciliation.release_id = NEW.active_release_id
     AND reconciliation.status = 'prepared'
     AND (
+      reconciliation.target_artifact_checksum <> COALESCE((
+        SELECT target_artifact.artifact_checksum
+        FROM superboard_plugin_target_artifacts target_artifact
+        WHERE target_artifact.instance_id = reconciliation.instance_id
+          AND target_artifact.target = reconciliation.target
+      ), '')
+      OR
       EXISTS (
         SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
         WHERE json_extract(lock.value, '$.plugin_id') <> 'supbrd-core'
@@ -266,6 +287,13 @@ WHEN EXISTS (
     AND reconciliation.release_id = NEW.active_release_id
     AND reconciliation.status = 'prepared'
     AND (
+      reconciliation.target_artifact_checksum <> COALESCE((
+        SELECT target_artifact.artifact_checksum
+        FROM superboard_plugin_target_artifacts target_artifact
+        WHERE target_artifact.instance_id = reconciliation.instance_id
+          AND target_artifact.target = reconciliation.target
+      ), '')
+      OR
       EXISTS (
         SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
         WHERE json_extract(lock.value, '$.plugin_id') <> 'supbrd-core'

--- a/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
+++ b/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
@@ -215,6 +215,92 @@ BEGIN
   SELECT RAISE(ABORT, 'plugin lifecycle reconciliation is not prepared');
 END;
 
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_insert_fresh_guard
+BEFORE INSERT ON superboard_front_active_releases
+WHEN EXISTS (
+  SELECT 1 FROM superboard_plugin_release_reconciliations reconciliation
+  WHERE reconciliation.instance_id = NEW.instance_id
+    AND reconciliation.release_id = NEW.active_release_id
+    AND reconciliation.status = 'prepared'
+    AND (
+      EXISTS (
+        SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+        WHERE json_extract(lock.value, '$.plugin_id') <> 'supbrd-core'
+          AND NOT EXISTS (
+            SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+            JOIN superboard_plugin_runtime_health health
+              ON health.instance_id = lifecycle.instance_id
+             AND health.target = lifecycle.target
+             AND health.plugin_id = lifecycle.plugin_id
+             AND health.artifact_checksum = lifecycle.artifact_checksum
+            WHERE lifecycle.instance_id = NEW.instance_id
+              AND lifecycle.target = reconciliation.target
+              AND lifecycle.plugin_id = json_extract(lock.value, '$.plugin_id')
+              AND lifecycle.artifact_checksum = json_extract(lock.value, '$.artifact_checksum')
+              AND lifecycle.state IN ('installed', 'active')
+              AND health.status = 'ready'
+              AND health.expires_at > NEW.activated_at
+          )
+      )
+      OR EXISTS (
+        SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+        WHERE lifecycle.instance_id = NEW.instance_id
+          AND lifecycle.target = reconciliation.target
+          AND lifecycle.state = 'active'
+          AND NOT EXISTS (
+            SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+            WHERE json_extract(lock.value, '$.plugin_id') = lifecycle.plugin_id
+          )
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle reconciliation is stale');
+END;
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_update_fresh_guard
+BEFORE UPDATE ON superboard_front_active_releases
+WHEN EXISTS (
+  SELECT 1 FROM superboard_plugin_release_reconciliations reconciliation
+  WHERE reconciliation.instance_id = NEW.instance_id
+    AND reconciliation.release_id = NEW.active_release_id
+    AND reconciliation.status = 'prepared'
+    AND (
+      EXISTS (
+        SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+        WHERE json_extract(lock.value, '$.plugin_id') <> 'supbrd-core'
+          AND NOT EXISTS (
+            SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+            JOIN superboard_plugin_runtime_health health
+              ON health.instance_id = lifecycle.instance_id
+             AND health.target = lifecycle.target
+             AND health.plugin_id = lifecycle.plugin_id
+             AND health.artifact_checksum = lifecycle.artifact_checksum
+            WHERE lifecycle.instance_id = NEW.instance_id
+              AND lifecycle.target = reconciliation.target
+              AND lifecycle.plugin_id = json_extract(lock.value, '$.plugin_id')
+              AND lifecycle.artifact_checksum = json_extract(lock.value, '$.artifact_checksum')
+              AND lifecycle.state IN ('installed', 'active')
+              AND health.status = 'ready'
+              AND health.expires_at > NEW.activated_at
+          )
+      )
+      OR EXISTS (
+        SELECT 1 FROM superboard_plugin_lifecycle lifecycle
+        WHERE lifecycle.instance_id = NEW.instance_id
+          AND lifecycle.target = reconciliation.target
+          AND lifecycle.state = 'active'
+          AND NOT EXISTS (
+            SELECT 1 FROM json_each(reconciliation.plugin_lock_json) lock
+            WHERE json_extract(lock.value, '$.plugin_id') = lifecycle.plugin_id
+          )
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle reconciliation is stale');
+END;
+
 CREATE TRIGGER IF NOT EXISTS superboard_plugin_release_reconciliation_apply
 AFTER INSERT ON superboard_front_activations
 BEGIN

--- a/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
+++ b/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
@@ -9,6 +9,8 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_installation_plans (
   plugin_count INTEGER NOT NULL CHECK (plugin_count > 0),
   created_at TEXT NOT NULL,
   completed_at TEXT,
+  compensation_status TEXT NOT NULL DEFAULT 'not_required'
+    CHECK (compensation_status IN ('not_required', 'completed', 'quarantined')),
   failure_json TEXT CHECK (failure_json IS NULL OR json_valid(failure_json)),
   UNIQUE(instance_id, target, plan_id)
 );
@@ -32,6 +34,26 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_installation_items (
 CREATE INDEX IF NOT EXISTS idx_plugin_installation_items_artifact
   ON superboard_plugin_installation_items(artifact_checksum);
 
+CREATE TABLE IF NOT EXISTS superboard_plugin_installation_steps (
+  plan_id TEXT NOT NULL
+    REFERENCES superboard_plugin_installation_plans(plan_id),
+  plugin_id TEXT NOT NULL,
+  step_name TEXT NOT NULL CHECK (
+    step_name IN ('artifact_verified', 'publisher_verified', 'capabilities_approved',
+                  'stores_provisioned', 'migration_graph_verified',
+                  'worker_deployed_inactive', 'health_verified', 'release_contract_ready')
+  ),
+  status TEXT NOT NULL CHECK (status IN ('completed', 'failed', 'compensated')),
+  receipt_checksum TEXT NOT NULL,
+  completed_at TEXT NOT NULL,
+  PRIMARY KEY (plan_id, plugin_id, step_name),
+  FOREIGN KEY (plan_id, plugin_id)
+    REFERENCES superboard_plugin_installation_items(plan_id, plugin_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_installation_steps_plan
+  ON superboard_plugin_installation_steps(plan_id, plugin_id);
+
 CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle (
   instance_id TEXT NOT NULL,
   target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
@@ -43,6 +65,7 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle (
               'disabled', 'quarantined', 'purged')
   ),
   plan_id TEXT REFERENCES superboard_plugin_installation_plans(plan_id),
+  activated_release_id TEXT,
   state_changed_at TEXT NOT NULL,
   reason TEXT,
   PRIMARY KEY (instance_id, target, plugin_id)
@@ -50,6 +73,48 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle (
 
 CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_active_scope
   ON superboard_plugin_lifecycle(instance_id, target, state, plugin_id);
+CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_artifact
+  ON superboard_plugin_lifecycle(artifact_checksum);
+CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_plan
+  ON superboard_plugin_lifecycle(plan_id);
+
+DROP TRIGGER IF EXISTS superboard_plugin_store_authority_insert_guard;
+CREATE TRIGGER superboard_plugin_store_authority_insert_guard
+BEFORE INSERT ON superboard_plugin_store_records
+WHEN NOT EXISTS (
+  SELECT 1 FROM superboard_plugin_lifecycle AS lifecycle
+  JOIN superboard_plugin_manifest_artifacts AS artifact
+    ON artifact.artifact_checksum = lifecycle.artifact_checksum
+  JOIN json_each(artifact.manifest_json, '$.stores') AS store
+  WHERE lifecycle.instance_id = NEW.instance_id
+    AND lifecycle.plugin_id = NEW.plugin_id
+    AND lifecycle.state = 'active'
+    AND lifecycle.artifact_checksum = NEW.manifest_artifact_checksum
+    AND json_extract(store.value, '$.store_id') = NEW.store_id
+    AND json_extract(store.value, '$.authority') = NEW.plugin_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin Store write authority rejected');
+END;
+
+DROP TRIGGER IF EXISTS superboard_plugin_store_authority_update_guard;
+CREATE TRIGGER superboard_plugin_store_authority_update_guard
+BEFORE UPDATE ON superboard_plugin_store_records
+WHEN NOT EXISTS (
+  SELECT 1 FROM superboard_plugin_lifecycle AS lifecycle
+  JOIN superboard_plugin_manifest_artifacts AS artifact
+    ON artifact.artifact_checksum = lifecycle.artifact_checksum
+  JOIN json_each(artifact.manifest_json, '$.stores') AS store
+  WHERE lifecycle.instance_id = NEW.instance_id
+    AND lifecycle.plugin_id = NEW.plugin_id
+    AND lifecycle.state = 'active'
+    AND lifecycle.artifact_checksum = NEW.manifest_artifact_checksum
+    AND json_extract(store.value, '$.store_id') = NEW.store_id
+    AND json_extract(store.value, '$.authority') = NEW.plugin_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'plugin Store write authority rejected');
+END;
 
 CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle_events (
   event_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -66,12 +131,15 @@ CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle_events (
                  'disabled', 'quarantined', 'purged')
   ),
   plan_id TEXT REFERENCES superboard_plugin_installation_plans(plan_id),
+  release_id TEXT,
   reason TEXT,
   changed_at TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_events_scope
   ON superboard_plugin_lifecycle_events(instance_id, target, plugin_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_events_plan
+  ON superboard_plugin_lifecycle_events(plan_id);
 
 CREATE TRIGGER IF NOT EXISTS superboard_plugin_lifecycle_events_immutable_update
 BEFORE UPDATE ON superboard_plugin_lifecycle_events

--- a/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
+++ b/apps/site/migrations/0019_data_driven_plugin_lifecycle.sql
@@ -1,0 +1,101 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_installation_plans (
+  plan_id TEXT PRIMARY KEY,
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  status TEXT NOT NULL CHECK (status IN ('installing', 'installed', 'active', 'failed')),
+  catalog_checksum TEXT NOT NULL,
+  plugin_count INTEGER NOT NULL CHECK (plugin_count > 0),
+  created_at TEXT NOT NULL,
+  completed_at TEXT,
+  failure_json TEXT CHECK (failure_json IS NULL OR json_valid(failure_json)),
+  UNIQUE(instance_id, target, plan_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_installation_plans_scope
+  ON superboard_plugin_installation_plans(instance_id, target, created_at);
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_installation_items (
+  plan_id TEXT NOT NULL
+    REFERENCES superboard_plugin_installation_plans(plan_id),
+  plugin_id TEXT NOT NULL,
+  artifact_checksum TEXT NOT NULL
+    REFERENCES superboard_plugin_manifest_artifacts(artifact_checksum),
+  state TEXT NOT NULL CHECK (state IN ('staged', 'installed', 'active', 'failed')),
+  derived_contract_json TEXT NOT NULL CHECK (json_valid(derived_contract_json)),
+  derived_contract_checksum TEXT NOT NULL,
+  health_status TEXT NOT NULL CHECK (health_status IN ('ready', 'unavailable')),
+  PRIMARY KEY (plan_id, plugin_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_installation_items_artifact
+  ON superboard_plugin_installation_items(artifact_checksum);
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle (
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  plugin_id TEXT NOT NULL,
+  artifact_checksum TEXT NOT NULL
+    REFERENCES superboard_plugin_manifest_artifacts(artifact_checksum),
+  state TEXT NOT NULL CHECK (
+    state IN ('available', 'staged', 'installed', 'active', 'draining',
+              'disabled', 'quarantined', 'purged')
+  ),
+  plan_id TEXT REFERENCES superboard_plugin_installation_plans(plan_id),
+  state_changed_at TEXT NOT NULL,
+  reason TEXT,
+  PRIMARY KEY (instance_id, target, plugin_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_active_scope
+  ON superboard_plugin_lifecycle(instance_id, target, state, plugin_id);
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_lifecycle_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  plugin_id TEXT NOT NULL,
+  artifact_checksum TEXT NOT NULL,
+  from_state TEXT CHECK (
+    from_state IS NULL OR from_state IN ('available', 'staged', 'installed', 'active',
+                                         'draining', 'disabled', 'quarantined', 'purged')
+  ),
+  to_state TEXT NOT NULL CHECK (
+    to_state IN ('available', 'staged', 'installed', 'active', 'draining',
+                 'disabled', 'quarantined', 'purged')
+  ),
+  plan_id TEXT REFERENCES superboard_plugin_installation_plans(plan_id),
+  reason TEXT,
+  changed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_lifecycle_events_scope
+  ON superboard_plugin_lifecycle_events(instance_id, target, plugin_id, event_id);
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_lifecycle_events_immutable_update
+BEFORE UPDATE ON superboard_plugin_lifecycle_events
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle events are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS superboard_plugin_lifecycle_events_immutable_delete
+BEFORE DELETE ON superboard_plugin_lifecycle_events
+BEGIN
+  SELECT RAISE(ABORT, 'plugin lifecycle events are immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS superboard_plugin_runtime_health (
+  instance_id TEXT NOT NULL,
+  target TEXT NOT NULL CHECK (target IN ('local', 'development', 'production')),
+  plugin_id TEXT NOT NULL,
+  artifact_checksum TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('ready', 'unavailable')),
+  evidence_checksum TEXT NOT NULL,
+  checked_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (instance_id, target, plugin_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plugin_runtime_health_ready
+  ON superboard_plugin_runtime_health(instance_id, target, status, expires_at);

--- a/apps/site/release-operator-api.mjs
+++ b/apps/site/release-operator-api.mjs
@@ -23,6 +23,15 @@ export function superboardReleaseOperatorApi() {
 					),
 				});
 				injectRoute({
+					pattern: "/_emdash/api/superboard/plugins/[pluginId]/lifecycle",
+					entrypoint: fileURLToPath(
+						new URL(
+							"./src/pages/_superboard/api/plugins/[pluginId]/lifecycle.ts",
+							import.meta.url,
+						),
+					),
+				});
+				injectRoute({
 					pattern: "/_emdash/api/superboard/plugins/stores",
 					entrypoint: fileURLToPath(
 						new URL("./src/pages/_superboard/api/plugins/stores.ts", import.meta.url),

--- a/apps/site/release-operator-api.test.mjs
+++ b/apps/site/release-operator-api.test.mjs
@@ -14,6 +14,7 @@ test("injects every release operator endpoint below the authenticated EmDash API
 		[
 			"/_emdash/api/superboard/plugins/user/install",
 			"/_emdash/api/superboard/plugins/sync",
+			"/_emdash/api/superboard/plugins/[pluginId]/lifecycle",
 			"/_emdash/api/superboard/plugins/stores",
 			"/_emdash/api/superboard/plugins/[pluginId]/data-sources/[dataSourceId]",
 			"/_emdash/superboard/releases/[candidateId]",

--- a/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
@@ -256,7 +256,42 @@ describe("SuperBoard plugin lifecycle", () => {
 			/PLUGIN_CATALOG_HEALTH_NOT_READY/u,
 		);
 	});
+
+	test("rejects a prepared Release when lifecycle changes before the pointer swap", async () => {
+		const staleScope = {
+			instance_id: "stale-preparation-instance",
+			target: "development" as const,
+			approved_by: "operator-1",
+		};
+		await installSuperBoardPluginCatalog(env.DB, {
+			...staleScope,
+			plan_id: "plugin-plan-stale-preparation",
+			checked_at: "2026-09-02T12:00:00.000Z",
+			expires_at: "2999-09-03T12:00:00.000Z",
+		});
+		const lock = await loadReleasableSuperBoardPluginLock(env.DB, staleScope);
+		const releaseId = "01J00000000000000000000455";
+		await stageReleaseCandidate(env.DB, staleScope.instance_id, releaseId, lock, staleScopeTime);
+		await prepareSuperBoardPluginLifecycleForRelease(env.DB, {
+			...staleScope,
+			release_id: releaseId,
+			plugin_lock: lock,
+			prepared_at: staleScopeTime,
+		});
+		await transitionSuperBoardPluginLifecycle(env.DB, {
+			...staleScope,
+			plugin_id: "supbrd-plug-user",
+			to_state: "quarantined",
+			changed_at: "2026-09-02T12:01:00.000Z",
+			reason: "integrity changed after preparation",
+		});
+		await expect(
+			activateReleasePointer(env.DB, staleScope.instance_id, releaseId, staleScopeTime),
+		).rejects.toThrow(/plugin lifecycle reconciliation is stale/u);
+	});
 });
+
+const staleScopeTime = "2026-09-02T12:05:00.000Z";
 
 async function activatePluginRelease(
 	db: D1Database,

--- a/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
@@ -2,9 +2,10 @@ import { env } from "cloudflare:workers";
 import { describe, expect, test } from "vitest";
 
 import {
-	activateSuperBoardPluginInstallationPlan,
 	installSuperBoardPluginCatalog,
+	reconcileSuperBoardPluginLifecycleForRelease,
 	loadActiveSuperBoardPluginLock,
+	loadReleasableSuperBoardPluginLock,
 	superBoardRuntimePluginCatalog,
 	transitionSuperBoardPluginLifecycle,
 } from "../src/lib/superboard-plugin-catalog.js";
@@ -13,6 +14,7 @@ import { composeUserFrontReleaseInput } from "../src/lib/user-front-release.js";
 const scope = {
 	instance_id: "blank-instance",
 	target: "development" as const,
+	approved_by: "operator-1",
 };
 
 describe("SuperBoard plugin lifecycle", () => {
@@ -57,6 +59,13 @@ describe("SuperBoard plugin lifecycle", () => {
 				}),
 			]),
 		);
+		const steps = await env.DB.prepare(
+			`SELECT COUNT(*) count FROM superboard_plugin_installation_steps
+			 WHERE plan_id = ? AND status = 'completed'`,
+		)
+			.bind(plan.plan_id)
+			.first<{ count: number }>();
+		expect(steps?.count).toBe(18 * 8);
 		await expect(loadActiveSuperBoardPluginLock(env.DB, scope)).rejects.toThrow(
 			"PLUGIN_CATALOG_ACTIVE_SET_EMPTY",
 		);
@@ -65,12 +74,22 @@ describe("SuperBoard plugin lifecycle", () => {
 		).first<{ count: number }>();
 		expect(installedStates?.count).toBe(18);
 
-		const activation = await activateSuperBoardPluginInstallationPlan(env.DB, {
+		const candidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
+		expect(candidateLock).toHaveLength(18);
+		await activateReleasePointer(
+			env.DB,
+			scope.instance_id,
+			"01J00000000000000000000405",
+			candidateLock,
+			"2026-09-02T08:05:00.000Z",
+		);
+		const activation = await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
 			...scope,
-			plan_id: plan.plan_id,
-			changed_at: "2026-09-02T08:05:00.000Z",
+			release_id: "01J00000000000000000000405",
+			plugin_lock: candidateLock,
+			activated_at: "2026-09-02T08:05:00.000Z",
 		});
-		expect(activation).toMatchObject({ status: "active", plugin_count: 18 });
+		expect(activation).toMatchObject({ status: "reconciled", plugin_count: 18 });
 		const activeStates = await env.DB.prepare(
 			"SELECT COUNT(*) count FROM _plugin_state WHERE status = 'active'",
 		).first<{ count: number }>();
@@ -90,16 +109,25 @@ describe("SuperBoard plugin lifecycle", () => {
 	});
 
 	test("disabled and quarantined states remove contributions without changing the catalog", async () => {
-		const plan = await installSuperBoardPluginCatalog(env.DB, {
+		await installSuperBoardPluginCatalog(env.DB, {
 			...scope,
 			plan_id: "plugin-plan-state-changes",
 			checked_at: "2026-09-02T09:00:00.000Z",
 			expires_at: "2026-09-03T09:00:00.000Z",
 		});
-		await activateSuperBoardPluginInstallationPlan(env.DB, {
+		const initialLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
+		await activateReleasePointer(
+			env.DB,
+			scope.instance_id,
+			"01J00000000000000000000415",
+			initialLock,
+			"2026-09-02T09:05:00.000Z",
+		);
+		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
 			...scope,
-			plan_id: plan.plan_id,
-			changed_at: "2026-09-02T09:05:00.000Z",
+			release_id: "01J00000000000000000000415",
+			plugin_lock: initialLock,
+			activated_at: "2026-09-02T09:05:00.000Z",
 		});
 
 		await transitionSuperBoardPluginLifecycle(env.DB, {
@@ -111,19 +139,27 @@ describe("SuperBoard plugin lifecycle", () => {
 		});
 		await transitionSuperBoardPluginLifecycle(env.DB, {
 			...scope,
-			plugin_id: "supbrd-plugmod-marketing",
-			to_state: "disabled",
-			changed_at: "2026-09-02T09:11:00.000Z",
-			reason: "drain complete",
-		});
-		await transitionSuperBoardPluginLifecycle(env.DB, {
-			...scope,
 			plugin_id: "supbrd-plugmod-analytics",
 			to_state: "quarantined",
 			changed_at: "2026-09-02T09:12:00.000Z",
 			reason: "integrity violation",
 		});
 
+		const reducedCandidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
+		expect(reducedCandidateLock).toHaveLength(16);
+		await activateReleasePointer(
+			env.DB,
+			scope.instance_id,
+			"01J00000000000000000000425",
+			reducedCandidateLock,
+			"2026-09-02T09:15:00.000Z",
+		);
+		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+			...scope,
+			release_id: "01J00000000000000000000425",
+			plugin_lock: reducedCandidateLock,
+			activated_at: "2026-09-02T09:15:00.000Z",
+		});
 		const reducedLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		expect(reducedLock).toHaveLength(16);
 		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
@@ -147,6 +183,7 @@ describe("SuperBoard plugin lifecycle", () => {
 		const plan = await installSuperBoardPluginCatalog(env.DB, {
 			instance_id: "tampered-instance",
 			target: "production",
+			approved_by: "operator-1",
 			plan_id: "plugin-plan-tampered-contract",
 			checked_at: "2026-09-02T10:00:00.000Z",
 			expires_at: "2026-09-03T10:00:00.000Z",
@@ -158,17 +195,99 @@ describe("SuperBoard plugin lifecycle", () => {
 		)
 			.bind(`sha256:${"f".repeat(64)}`, plan.plan_id)
 			.run();
+		const tamperedLock = plan.plugins.map(({ derived }) => derived.plugin_lock);
+		await activateReleasePointer(
+			env.DB,
+			"tampered-instance",
+			"01J00000000000000000000435",
+			tamperedLock,
+			"2026-09-02T10:05:00.000Z",
+		);
 
 		await expect(
-			activateSuperBoardPluginInstallationPlan(env.DB, {
+			reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
 				instance_id: "tampered-instance",
 				target: "production",
-				plan_id: plan.plan_id,
-				changed_at: "2026-09-02T10:05:00.000Z",
+				release_id: "01J00000000000000000000435",
+				plugin_lock: tamperedLock,
+				activated_at: "2026-09-02T10:05:00.000Z",
 			}),
 		).rejects.toThrow("PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:supbrd-plug-user");
 	});
+
+	test("cannot activate plugins before the corresponding Front Release is active", async () => {
+		const inactiveScope = {
+			instance_id: "release-gated-instance",
+			target: "local" as const,
+			approved_by: "operator-1",
+		};
+		await installSuperBoardPluginCatalog(env.DB, {
+			...inactiveScope,
+			plan_id: "plugin-plan-release-gated",
+			checked_at: "2026-09-02T11:00:00.000Z",
+			expires_at: "2026-09-03T11:00:00.000Z",
+		});
+		const lock = await loadReleasableSuperBoardPluginLock(env.DB, inactiveScope);
+		await expect(
+			reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+				...inactiveScope,
+				release_id: "01J00000000000000000000445",
+				plugin_lock: lock,
+				activated_at: "2026-09-02T11:05:00.000Z",
+			}),
+		).rejects.toThrow("PLUGIN_RELEASE_NOT_ACTIVE");
+	});
 });
+
+async function activateReleasePointer(
+	db: D1Database,
+	instanceId: string,
+	releaseId: string,
+	pluginLock: readonly unknown[],
+	activatedAt: string,
+) {
+	const candidateId = `${releaseId}-candidate`;
+	await db.batch([
+		db
+			.prepare(
+				`INSERT INTO superboard_release_signing_keys
+				 (kid, public_jwk, status, created_at, retired_at)
+				 VALUES ('plugin-lifecycle-test-key', '{}', 'active', ?, NULL)
+				 ON CONFLICT(kid) DO NOTHING`,
+			)
+			.bind(activatedAt),
+		db
+			.prepare(
+				`INSERT INTO superboard_front_release_candidates
+				 (candidate_id, instance_id, release_id, release_json, content_checksum,
+				  validation_set_checksum, signing_kid, status, approval_json, created_at, approved_at)
+				 VALUES (?, ?, ?, ?, 'sha256:test', 'sha256:test',
+				         'plugin-lifecycle-test-key', 'approved', '{}', ?, ?)`,
+			)
+			.bind(
+				candidateId,
+				instanceId,
+				releaseId,
+				JSON.stringify({ payload: { plugin_lock: pluginLock } }),
+				activatedAt,
+				activatedAt,
+			),
+		db
+			.prepare(
+				`INSERT INTO superboard_front_active_releases
+				 (instance_id, active_release_id, previous_release_id, pointer_revision,
+				  activation_id, activated_at)
+				 VALUES (?, ?, NULL, 1, ?, ?)
+				 ON CONFLICT(instance_id) DO UPDATE SET
+				   previous_release_id = superboard_front_active_releases.active_release_id,
+				   active_release_id = excluded.active_release_id,
+				   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
+				   activation_id = excluded.activation_id,
+				   activated_at = excluded.activated_at`,
+			)
+			.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt),
+	]);
+}
 
 const releaseIdentifiers = {
 	instance_id: scope.instance_id,

--- a/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
@@ -2,10 +2,11 @@ import { env } from "cloudflare:workers";
 import { describe, expect, test } from "vitest";
 
 import {
+	finalizeSuperBoardPluginLifecycleForRelease,
 	installSuperBoardPluginCatalog,
-	reconcileSuperBoardPluginLifecycleForRelease,
 	loadActiveSuperBoardPluginLock,
 	loadReleasableSuperBoardPluginLock,
+	prepareSuperBoardPluginLifecycleForRelease,
 	superBoardRuntimePluginCatalog,
 	transitionSuperBoardPluginLifecycle,
 } from "../src/lib/superboard-plugin-catalog.js";
@@ -34,7 +35,7 @@ describe("SuperBoard plugin lifecycle", () => {
 			...scope,
 			plan_id: "plugin-plan-blank-instance",
 			checked_at: "2026-09-02T08:00:00.000Z",
-			expires_at: "2026-09-03T08:00:00.000Z",
+			expires_at: "2999-09-03T08:00:00.000Z",
 		});
 
 		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
@@ -76,19 +77,13 @@ describe("SuperBoard plugin lifecycle", () => {
 
 		const candidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
 		expect(candidateLock).toHaveLength(18);
-		await activateReleasePointer(
+		const activation = await activatePluginRelease(
 			env.DB,
-			scope.instance_id,
+			scope,
 			"01J00000000000000000000405",
 			candidateLock,
 			"2026-09-02T08:05:00.000Z",
 		);
-		const activation = await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
-			...scope,
-			release_id: "01J00000000000000000000405",
-			plugin_lock: candidateLock,
-			activated_at: "2026-09-02T08:05:00.000Z",
-		});
 		expect(activation).toMatchObject({ status: "reconciled", plugin_count: 18 });
 		const activeStates = await env.DB.prepare(
 			"SELECT COUNT(*) count FROM _plugin_state WHERE status = 'active'",
@@ -113,23 +108,16 @@ describe("SuperBoard plugin lifecycle", () => {
 			...scope,
 			plan_id: "plugin-plan-state-changes",
 			checked_at: "2026-09-02T09:00:00.000Z",
-			expires_at: "2026-09-03T09:00:00.000Z",
+			expires_at: "2999-09-03T09:00:00.000Z",
 		});
 		const initialLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
-		await activateReleasePointer(
+		await activatePluginRelease(
 			env.DB,
-			scope.instance_id,
+			scope,
 			"01J00000000000000000000415",
 			initialLock,
 			"2026-09-02T09:05:00.000Z",
 		);
-		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
-			...scope,
-			release_id: "01J00000000000000000000415",
-			plugin_lock: initialLock,
-			activated_at: "2026-09-02T09:05:00.000Z",
-		});
-
 		await transitionSuperBoardPluginLifecycle(env.DB, {
 			...scope,
 			plugin_id: "supbrd-plugmod-marketing",
@@ -147,19 +135,13 @@ describe("SuperBoard plugin lifecycle", () => {
 
 		const reducedCandidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
 		expect(reducedCandidateLock).toHaveLength(16);
-		await activateReleasePointer(
+		await activatePluginRelease(
 			env.DB,
-			scope.instance_id,
+			scope,
 			"01J00000000000000000000425",
 			reducedCandidateLock,
 			"2026-09-02T09:15:00.000Z",
 		);
-		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
-			...scope,
-			release_id: "01J00000000000000000000425",
-			plugin_lock: reducedCandidateLock,
-			activated_at: "2026-09-02T09:15:00.000Z",
-		});
 		const reducedLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		expect(reducedLock).toHaveLength(16);
 		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
@@ -186,7 +168,7 @@ describe("SuperBoard plugin lifecycle", () => {
 			approved_by: "operator-1",
 			plan_id: "plugin-plan-tampered-contract",
 			checked_at: "2026-09-02T10:00:00.000Z",
-			expires_at: "2026-09-03T10:00:00.000Z",
+			expires_at: "2999-09-03T10:00:00.000Z",
 		});
 		await env.DB.prepare(
 			`UPDATE superboard_plugin_installation_items
@@ -196,7 +178,7 @@ describe("SuperBoard plugin lifecycle", () => {
 			.bind(`sha256:${"f".repeat(64)}`, plan.plan_id)
 			.run();
 		const tamperedLock = plan.plugins.map(({ derived }) => derived.plugin_lock);
-		await activateReleasePointer(
+		await stageReleaseCandidate(
 			env.DB,
 			"tampered-instance",
 			"01J00000000000000000000435",
@@ -205,12 +187,12 @@ describe("SuperBoard plugin lifecycle", () => {
 		);
 
 		await expect(
-			reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+			prepareSuperBoardPluginLifecycleForRelease(env.DB, {
 				instance_id: "tampered-instance",
 				target: "production",
 				release_id: "01J00000000000000000000435",
 				plugin_lock: tamperedLock,
-				activated_at: "2026-09-02T10:05:00.000Z",
+				prepared_at: "2026-09-02T10:05:00.000Z",
 			}),
 		).rejects.toThrow("PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:supbrd-plug-user");
 	});
@@ -225,25 +207,84 @@ describe("SuperBoard plugin lifecycle", () => {
 			...inactiveScope,
 			plan_id: "plugin-plan-release-gated",
 			checked_at: "2026-09-02T11:00:00.000Z",
-			expires_at: "2026-09-03T11:00:00.000Z",
+			expires_at: "2999-09-03T11:00:00.000Z",
 		});
 		const lock = await loadReleasableSuperBoardPluginLock(env.DB, inactiveScope);
+		await stageReleaseCandidate(
+			env.DB,
+			inactiveScope.instance_id,
+			"01J00000000000000000000445",
+			lock,
+			"2026-09-02T11:05:00.000Z",
+		);
 		await expect(
-			reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+			activateReleasePointer(
+				env.DB,
+				inactiveScope.instance_id,
+				"01J00000000000000000000445",
+				"2026-09-02T11:05:00.000Z",
+			),
+		).rejects.toThrow(/plugin lifecycle reconciliation is not prepared/u);
+		await prepareSuperBoardPluginLifecycleForRelease(env.DB, {
+			...inactiveScope,
+			release_id: "01J00000000000000000000445",
+			plugin_lock: lock,
+			prepared_at: "2026-09-02T11:05:00.000Z",
+		});
+		await expect(
+			finalizeSuperBoardPluginLifecycleForRelease(env.DB, {
 				...inactiveScope,
 				release_id: "01J00000000000000000000445",
-				plugin_lock: lock,
-				activated_at: "2026-09-02T11:05:00.000Z",
+				finalized_at: "2026-09-02T11:05:00.000Z",
 			}),
-		).rejects.toThrow("PLUGIN_RELEASE_NOT_ACTIVE");
+		).rejects.toThrow("PLUGIN_RELEASE_RECONCILIATION_NOT_APPLIED");
+	});
+
+	test("rejects a Plugin Lock when its health evidence has expired", async () => {
+		const expiredScope = {
+			instance_id: "expired-health-instance",
+			target: "local" as const,
+			approved_by: "operator-1",
+		};
+		await installSuperBoardPluginCatalog(env.DB, {
+			...expiredScope,
+			plan_id: "plugin-plan-expired-health",
+			checked_at: "2026-09-02T07:00:00.000Z",
+			expires_at: "2026-09-02T07:01:00.000Z",
+		});
+		await expect(loadReleasableSuperBoardPluginLock(env.DB, expiredScope)).rejects.toThrow(
+			/PLUGIN_CATALOG_HEALTH_NOT_READY/u,
+		);
 	});
 });
 
-async function activateReleasePointer(
+async function activatePluginRelease(
+	db: D1Database,
+	releaseScope: { instance_id: string; target: "local" | "development" | "production" },
+	releaseId: string,
+	pluginLock: Parameters<typeof prepareSuperBoardPluginLifecycleForRelease>[1]["plugin_lock"],
+	activatedAt: string,
+) {
+	await stageReleaseCandidate(db, releaseScope.instance_id, releaseId, pluginLock, activatedAt);
+	await prepareSuperBoardPluginLifecycleForRelease(db, {
+		...releaseScope,
+		release_id: releaseId,
+		plugin_lock: pluginLock,
+		prepared_at: activatedAt,
+	});
+	await activateReleasePointer(db, releaseScope.instance_id, releaseId, activatedAt);
+	return finalizeSuperBoardPluginLifecycleForRelease(db, {
+		...releaseScope,
+		release_id: releaseId,
+		finalized_at: activatedAt,
+	});
+}
+
+async function stageReleaseCandidate(
 	db: D1Database,
 	instanceId: string,
 	releaseId: string,
-	pluginLock: readonly unknown[],
+	pluginLock: Parameters<typeof prepareSuperBoardPluginLifecycleForRelease>[1]["plugin_lock"],
 	activatedAt: string,
 ) {
 	const candidateId = `${releaseId}-candidate`;
@@ -272,21 +313,30 @@ async function activateReleasePointer(
 				activatedAt,
 				activatedAt,
 			),
-		db
-			.prepare(
-				`INSERT INTO superboard_front_active_releases
-				 (instance_id, active_release_id, previous_release_id, pointer_revision,
-				  activation_id, activated_at)
-				 VALUES (?, ?, NULL, 1, ?, ?)
-				 ON CONFLICT(instance_id) DO UPDATE SET
-				   previous_release_id = superboard_front_active_releases.active_release_id,
-				   active_release_id = excluded.active_release_id,
-				   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
-				   activation_id = excluded.activation_id,
-				   activated_at = excluded.activated_at`,
-			)
-			.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt),
 	]);
+}
+
+async function activateReleasePointer(
+	db: D1Database,
+	instanceId: string,
+	releaseId: string,
+	activatedAt: string,
+) {
+	await db
+		.prepare(
+			`INSERT INTO superboard_front_active_releases
+			 (instance_id, active_release_id, previous_release_id, pointer_revision,
+			  activation_id, activated_at)
+			 VALUES (?, ?, NULL, 1, ?, ?)
+			 ON CONFLICT(instance_id) DO UPDATE SET
+			   previous_release_id = superboard_front_active_releases.active_release_id,
+			   active_release_id = excluded.active_release_id,
+			   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
+			   activation_id = excluded.activation_id,
+			   activated_at = excluded.activated_at`,
+		)
+		.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt)
+		.run();
 }
 
 const releaseIdentifiers = {

--- a/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
@@ -1,0 +1,183 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, test } from "vitest";
+
+import {
+	activateSuperBoardPluginInstallationPlan,
+	installSuperBoardPluginCatalog,
+	loadActiveSuperBoardPluginLock,
+	superBoardRuntimePluginCatalog,
+	transitionSuperBoardPluginLifecycle,
+} from "../src/lib/superboard-plugin-catalog.js";
+import { composeUserFrontReleaseInput } from "../src/lib/user-front-release.js";
+
+const scope = {
+	instance_id: "blank-instance",
+	target: "development" as const,
+};
+
+describe("SuperBoard plugin lifecycle", () => {
+	test("installs all manifests through a plan before explicit activation", async () => {
+		await env.DB.prepare(
+			`CREATE TABLE IF NOT EXISTS _plugin_state (
+			  plugin_id TEXT PRIMARY KEY,
+			  version TEXT NOT NULL,
+			  status TEXT NOT NULL DEFAULT 'installed',
+			  installed_at TEXT,
+			  activated_at TEXT,
+			  deactivated_at TEXT,
+			  source TEXT NOT NULL DEFAULT 'config'
+			)`,
+		).run();
+		const plan = await installSuperBoardPluginCatalog(env.DB, {
+			...scope,
+			plan_id: "plugin-plan-blank-instance",
+			checked_at: "2026-09-02T08:00:00.000Z",
+			expires_at: "2026-09-03T08:00:00.000Z",
+		});
+
+		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
+		expect(plan).toMatchObject({
+			status: "installed",
+			plugin_count: 18,
+			target: "development",
+		});
+		expect(plan.plugins).toHaveLength(18);
+		expect(plan.plugins).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					plugin_id: "supbrd-plugmod-analytics",
+					state: "installed",
+					derived: expect.objectContaining({
+						stores: expect.any(Array),
+						capabilities: expect.any(Array),
+						settings_checksum: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+						contributions_checksum: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+						worker_descriptor_checksum: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+					}),
+				}),
+			]),
+		);
+		await expect(loadActiveSuperBoardPluginLock(env.DB, scope)).rejects.toThrow(
+			"PLUGIN_CATALOG_ACTIVE_SET_EMPTY",
+		);
+		const installedStates = await env.DB.prepare(
+			"SELECT COUNT(*) count FROM _plugin_state WHERE status = 'inactive'",
+		).first<{ count: number }>();
+		expect(installedStates?.count).toBe(18);
+
+		const activation = await activateSuperBoardPluginInstallationPlan(env.DB, {
+			...scope,
+			plan_id: plan.plan_id,
+			changed_at: "2026-09-02T08:05:00.000Z",
+		});
+		expect(activation).toMatchObject({ status: "active", plugin_count: 18 });
+		const activeStates = await env.DB.prepare(
+			"SELECT COUNT(*) count FROM _plugin_state WHERE status = 'active'",
+		).first<{ count: number }>();
+		expect(activeStates?.count).toBe(18);
+
+		const fullLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
+		expect(fullLock).toHaveLength(18);
+		const presentation = await composeUserFrontReleaseInput({
+			...releaseIdentifiers,
+			plugin_lock: fullLock,
+		});
+		expect(
+			presentation.front_route_manifest.routes.some(
+				({ path_pattern: path }) => path === "/marketing/campaigns",
+			),
+		).toBe(true);
+	});
+
+	test("disabled and quarantined states remove contributions without changing the catalog", async () => {
+		const plan = await installSuperBoardPluginCatalog(env.DB, {
+			...scope,
+			plan_id: "plugin-plan-state-changes",
+			checked_at: "2026-09-02T09:00:00.000Z",
+			expires_at: "2026-09-03T09:00:00.000Z",
+		});
+		await activateSuperBoardPluginInstallationPlan(env.DB, {
+			...scope,
+			plan_id: plan.plan_id,
+			changed_at: "2026-09-02T09:05:00.000Z",
+		});
+
+		await transitionSuperBoardPluginLifecycle(env.DB, {
+			...scope,
+			plugin_id: "supbrd-plugmod-marketing",
+			to_state: "draining",
+			changed_at: "2026-09-02T09:10:00.000Z",
+			reason: "operator disable",
+		});
+		await transitionSuperBoardPluginLifecycle(env.DB, {
+			...scope,
+			plugin_id: "supbrd-plugmod-marketing",
+			to_state: "disabled",
+			changed_at: "2026-09-02T09:11:00.000Z",
+			reason: "drain complete",
+		});
+		await transitionSuperBoardPluginLifecycle(env.DB, {
+			...scope,
+			plugin_id: "supbrd-plugmod-analytics",
+			to_state: "quarantined",
+			changed_at: "2026-09-02T09:12:00.000Z",
+			reason: "integrity violation",
+		});
+
+		const reducedLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
+		expect(reducedLock).toHaveLength(16);
+		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
+		const presentation = await composeUserFrontReleaseInput({
+			...releaseIdentifiers,
+			plugin_lock: reducedLock,
+		});
+		expect(
+			presentation.front_route_manifest.routes.some(
+				({ path_pattern: path }) => path === "/marketing/campaigns",
+			),
+		).toBe(false);
+		expect(
+			presentation.front_route_manifest.routes.some(
+				({ path_pattern: path }) => path === "/analytics/reports",
+			),
+		).toBe(false);
+	});
+
+	test("rejects an installation plan whose derived contract was modified", async () => {
+		const plan = await installSuperBoardPluginCatalog(env.DB, {
+			instance_id: "tampered-instance",
+			target: "production",
+			plan_id: "plugin-plan-tampered-contract",
+			checked_at: "2026-09-02T10:00:00.000Z",
+			expires_at: "2026-09-03T10:00:00.000Z",
+		});
+		await env.DB.prepare(
+			`UPDATE superboard_plugin_installation_items
+			 SET derived_contract_json = json_set(derived_contract_json, '$.settings_checksum', ?)
+			 WHERE plan_id = ? AND plugin_id = 'supbrd-plug-user'`,
+		)
+			.bind(`sha256:${"f".repeat(64)}`, plan.plan_id)
+			.run();
+
+		await expect(
+			activateSuperBoardPluginInstallationPlan(env.DB, {
+				instance_id: "tampered-instance",
+				target: "production",
+				plan_id: plan.plan_id,
+				changed_at: "2026-09-02T10:05:00.000Z",
+			}),
+		).rejects.toThrow("PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:supbrd-plug-user");
+	});
+});
+
+const releaseIdentifiers = {
+	instance_id: scope.instance_id,
+	front_draft_id: "01J00000000000000000000401",
+	draft_snapshot_id: "01J00000000000000000000402",
+	compilation_id: "01J00000000000000000000403",
+	candidate_id: "01J00000000000000000000404",
+	release_id: "01J00000000000000000000405",
+	release_sequence: 1,
+	previous_release_id: null,
+	created_at: "2026-09-02T08:10:00.000Z",
+};

--- a/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-lifecycle.runtime.test.ts
@@ -12,7 +12,14 @@ import {
 } from "../src/lib/superboard-plugin-catalog.js";
 import { composeUserFrontReleaseInput } from "../src/lib/user-front-release.js";
 
+const targetProof = {
+	target_artifact_checksum: `sha256:${"1".repeat(64)}`,
+	target_plugin_ids: superBoardRuntimePluginCatalog().plugins.map(
+		({ manifest }) => manifest.plugin_id,
+	),
+};
 const scope = {
+	...targetProof,
 	instance_id: "blank-instance",
 	target: "development" as const,
 	approved_by: "operator-1",
@@ -43,6 +50,7 @@ describe("SuperBoard plugin lifecycle", () => {
 			status: "installed",
 			plugin_count: 18,
 			target: "development",
+			target_artifact_checksum: targetProof.target_artifact_checksum,
 		});
 		expect(plan.plugins).toHaveLength(18);
 		expect(plan.plugins).toEqual(
@@ -163,6 +171,7 @@ describe("SuperBoard plugin lifecycle", () => {
 
 	test("rejects an installation plan whose derived contract was modified", async () => {
 		const plan = await installSuperBoardPluginCatalog(env.DB, {
+			...targetProof,
 			instance_id: "tampered-instance",
 			target: "production",
 			approved_by: "operator-1",
@@ -199,6 +208,7 @@ describe("SuperBoard plugin lifecycle", () => {
 
 	test("cannot activate plugins before the corresponding Front Release is active", async () => {
 		const inactiveScope = {
+			...targetProof,
 			instance_id: "release-gated-instance",
 			target: "local" as const,
 			approved_by: "operator-1",
@@ -242,6 +252,7 @@ describe("SuperBoard plugin lifecycle", () => {
 
 	test("rejects a Plugin Lock when its health evidence has expired", async () => {
 		const expiredScope = {
+			...targetProof,
 			instance_id: "expired-health-instance",
 			target: "local" as const,
 			approved_by: "operator-1",
@@ -259,6 +270,7 @@ describe("SuperBoard plugin lifecycle", () => {
 
 	test("rejects a prepared Release when lifecycle changes before the pointer swap", async () => {
 		const staleScope = {
+			...targetProof,
 			instance_id: "stale-preparation-instance",
 			target: "development" as const,
 			approved_by: "operator-1",
@@ -288,6 +300,36 @@ describe("SuperBoard plugin lifecycle", () => {
 		await expect(
 			activateReleasePointer(env.DB, staleScope.instance_id, releaseId, staleScopeTime),
 		).rejects.toThrow(/plugin lifecycle reconciliation is stale/u);
+	});
+
+	test("keeps plugins outside the compiled target available but not releasable", async () => {
+		const targetPluginIds = targetProof.target_plugin_ids.filter(
+			(pluginId) =>
+				pluginId !== "supbrd-plugmod-paywalls" && pluginId !== "supbrd-plugmod-onboardings",
+		);
+		const targetScope = {
+			instance_id: "feature-scoped-instance",
+			target: "development" as const,
+			approved_by: "operator-1",
+			target_artifact_checksum: `sha256:${"2".repeat(64)}`,
+			target_plugin_ids: targetPluginIds,
+		};
+		const plan = await installSuperBoardPluginCatalog(env.DB, {
+			...targetScope,
+			plan_id: "plugin-plan-feature-scoped",
+			checked_at: "2026-09-02T13:00:00.000Z",
+			expires_at: "2999-09-03T13:00:00.000Z",
+		});
+		expect(plan.plugin_count).toBe(16);
+		expect(await loadReleasableSuperBoardPluginLock(env.DB, targetScope)).toHaveLength(16);
+		const available = await env.DB.prepare(
+			`SELECT COUNT(*) count FROM superboard_plugin_lifecycle
+			 WHERE instance_id = ? AND target = ? AND state = 'available'`,
+		)
+			.bind(targetScope.instance_id, targetScope.target)
+			.first<{ count: number }>();
+		expect(available?.count).toBe(2);
+		expect(superBoardRuntimePluginCatalog().plugins).toHaveLength(18);
 	});
 });
 

--- a/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
@@ -24,9 +24,10 @@ import {
 	verifyPluginStoreShadowRead,
 } from "../src/lib/plugin-store-repository.js";
 import {
+	finalizeSuperBoardPluginLifecycleForRelease,
 	loadActiveSuperBoardPluginLock,
 	loadReleasableSuperBoardPluginLock,
-	reconcileSuperBoardPluginLifecycleForRelease,
+	prepareSuperBoardPluginLifecycleForRelease,
 	superBoardRuntimePluginCatalog,
 	synchronizeSuperBoardPluginCatalog,
 } from "../src/lib/superboard-plugin-catalog.js";
@@ -40,7 +41,7 @@ describe("EmDash plugin Store authority", () => {
 			...scope,
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:20:00.000Z",
-			expires_at: "2026-08-31T08:20:00.000Z",
+			expires_at: "2999-08-31T08:20:00.000Z",
 		});
 		expect(receipt.installed).toHaveLength(18);
 		expect(receipt.templates).toEqual(["supbrd-plugmod-custom-*"]);
@@ -66,19 +67,13 @@ describe("EmDash plugin Store authority", () => {
 			.first<{ count: number }>();
 		expect(health?.count).toBe(18);
 		const candidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
-		await activateReleasePointer(
+		await activatePluginRelease(
 			env.DB,
-			scope.instance_id,
+			scope,
 			"01J00000000000000000000501",
 			candidateLock,
 			"2026-08-30T08:25:00.000Z",
 		);
-		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
-			...scope,
-			release_id: "01J00000000000000000000501",
-			plugin_lock: candidateLock,
-			activated_at: "2026-08-30T08:25:00.000Z",
-		});
 		const fullLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		const fullPresentation = await composeUserFrontReleaseInput({
 			...releaseIdentifiers,
@@ -157,7 +152,7 @@ describe("EmDash plugin Store authority", () => {
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:30:00.000Z",
-			expires_at: "2026-08-30T09:30:00.000Z",
+			expires_at: "2999-08-30T09:30:00.000Z",
 		});
 		expect(receipt).toMatchObject({
 			plugin_id: userPluginManifest.plugin_id,
@@ -266,7 +261,7 @@ describe("EmDash plugin Store authority", () => {
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:20:00.000Z",
-			expires_at: "2026-08-31T08:20:00.000Z",
+			expires_at: "2999-08-31T08:20:00.000Z",
 		});
 		const encryptionKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
 			"encrypt",
@@ -336,7 +331,7 @@ describe("EmDash plugin Store authority", () => {
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T09:10:00.000Z",
-			expires_at: "2026-08-31T09:10:00.000Z",
+			expires_at: "2999-08-31T09:10:00.000Z",
 		});
 		const rawKey = crypto.getRandomValues(new Uint8Array(32));
 		const encodedKey = btoa(String.fromCodePoint(...rawKey));
@@ -540,23 +535,17 @@ describe("EmDash plugin Store authority", () => {
 			target: "local",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T02:00:00.000Z",
-			expires_at: "2026-08-31T02:00:00.000Z",
+			expires_at: "2999-08-31T02:00:00.000Z",
 		});
 		const parityScope = { instance_id: "parity-all", target: "local" as const };
 		const parityLock = await loadReleasableSuperBoardPluginLock(env.DB, parityScope);
-		await activateReleasePointer(
+		await activatePluginRelease(
 			env.DB,
-			parityScope.instance_id,
+			parityScope,
 			"01J00000000000000000000511",
 			parityLock,
 			"2026-08-30T02:01:00.000Z",
 		);
-		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
-			...parityScope,
-			release_id: "01J00000000000000000000511",
-			plugin_lock: parityLock,
-			activated_at: "2026-08-30T02:01:00.000Z",
-		});
 		const encryptionKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
 			"encrypt",
 			"decrypt",
@@ -610,13 +599,14 @@ describe("EmDash plugin Store authority", () => {
 	});
 });
 
-async function activateReleasePointer(
+async function activatePluginRelease(
 	db: D1Database,
-	instanceId: string,
+	releaseScope: { instance_id: string; target: "local" | "development" | "production" },
 	releaseId: string,
-	pluginLock: readonly unknown[],
+	pluginLock: Parameters<typeof prepareSuperBoardPluginLifecycleForRelease>[1]["plugin_lock"],
 	activatedAt: string,
 ) {
+	const instanceId = releaseScope.instance_id;
 	await db.batch([
 		db
 			.prepare(
@@ -642,21 +632,33 @@ async function activateReleasePointer(
 				activatedAt,
 				activatedAt,
 			),
-		db
-			.prepare(
-				`INSERT INTO superboard_front_active_releases
-				 (instance_id, active_release_id, previous_release_id, pointer_revision,
-				  activation_id, activated_at)
-				 VALUES (?, ?, NULL, 1, ?, ?)
-				 ON CONFLICT(instance_id) DO UPDATE SET
-				   previous_release_id = superboard_front_active_releases.active_release_id,
-				   active_release_id = excluded.active_release_id,
-				   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
-				   activation_id = excluded.activation_id,
-				   activated_at = excluded.activated_at`,
-			)
-			.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt),
 	]);
+	await prepareSuperBoardPluginLifecycleForRelease(db, {
+		...releaseScope,
+		release_id: releaseId,
+		plugin_lock: pluginLock,
+		prepared_at: activatedAt,
+	});
+	await db
+		.prepare(
+			`INSERT INTO superboard_front_active_releases
+			 (instance_id, active_release_id, previous_release_id, pointer_revision,
+			  activation_id, activated_at)
+			 VALUES (?, ?, NULL, 1, ?, ?)
+			 ON CONFLICT(instance_id) DO UPDATE SET
+			   previous_release_id = superboard_front_active_releases.active_release_id,
+			   active_release_id = excluded.active_release_id,
+			   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
+			   activation_id = excluded.activation_id,
+			   activated_at = excluded.activated_at`,
+		)
+		.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt)
+		.run();
+	return finalizeSuperBoardPluginLifecycleForRelease(db, {
+		...releaseScope,
+		release_id: releaseId,
+		finalized_at: activatedAt,
+	});
 }
 
 const releaseIdentifiers = {

--- a/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
@@ -34,9 +34,16 @@ import {
 import { composeUserFrontReleaseInput } from "../src/lib/user-front-release.js";
 import { installCompiledUserPlugin } from "../src/lib/user-plugin-installation.js";
 
+const targetProof = {
+	target_artifact_checksum: `sha256:${"3".repeat(64)}`,
+	target_plugin_ids: superBoardRuntimePluginCatalog().plugins.map(
+		({ manifest }) => manifest.plugin_id,
+	),
+};
+
 describe("EmDash plugin Store authority", () => {
 	test("synchronizes every concrete SuperBoard plugin into the EmDash runtime lifecycle", async () => {
-		const scope = { instance_id: "vocostar", target: "local" as const };
+		const scope = { ...targetProof, instance_id: "vocostar", target: "local" as const };
 		const receipt = await synchronizeSuperBoardPluginCatalog(env.DB, {
 			...scope,
 			approved_by: "operator-1",
@@ -149,6 +156,7 @@ describe("EmDash plugin Store authority", () => {
 
 	test("installs the exact compiled user plugin and publishes bounded dependency health", async () => {
 		const receipt = await installCompiledUserPlugin(env.DB, {
+			...targetProof,
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:30:00.000Z",
@@ -258,6 +266,7 @@ describe("EmDash plugin Store authority", () => {
 
 	test("commits compatibility mutations before transient execution and replays receipts", async () => {
 		await synchronizeSuperBoardPluginCatalog(env.DB, {
+			...targetProof,
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:20:00.000Z",
@@ -328,6 +337,7 @@ describe("EmDash plugin Store authority", () => {
 
 	test("keeps the compatibility Worker transient behind the repository-first gateway", async () => {
 		await synchronizeSuperBoardPluginCatalog(env.DB, {
+			...targetProof,
 			instance_id: "vocostar",
 			approved_by: "operator-1",
 			checked_at: "2026-08-30T09:10:00.000Z",
@@ -531,6 +541,7 @@ describe("EmDash plugin Store authority", () => {
 
 	test("rehearses encrypted idempotent authority for every declared domain Store", async () => {
 		await synchronizeSuperBoardPluginCatalog(env.DB, {
+			...targetProof,
 			instance_id: "parity-all",
 			target: "local",
 			approved_by: "operator-1",

--- a/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
@@ -33,19 +33,9 @@ import { installCompiledUserPlugin } from "../src/lib/user-plugin-installation.j
 
 describe("EmDash plugin Store authority", () => {
 	test("synchronizes every concrete SuperBoard plugin into the EmDash runtime lifecycle", async () => {
-		await env.DB.prepare(
-			`CREATE TABLE IF NOT EXISTS _plugin_state (
-			  plugin_id TEXT PRIMARY KEY, version TEXT NOT NULL,
-			  status TEXT NOT NULL DEFAULT 'installed', installed_at TEXT DEFAULT (datetime('now')),
-			  activated_at TEXT, deactivated_at TEXT, data TEXT,
-			  source TEXT NOT NULL DEFAULT 'config', marketplace_version TEXT,
-			  display_name TEXT, description TEXT, registry_publisher_did TEXT,
-			  registry_slug TEXT, mcp_tools_enabled INTEGER NOT NULL DEFAULT 0,
-			  mcp_tools_consent TEXT
-			)`,
-		).run();
+		const scope = { instance_id: "vocostar", target: "local" as const };
 		const receipt = await synchronizeSuperBoardPluginCatalog(env.DB, {
-			instance_id: "vocostar",
+			...scope,
 			checked_at: "2026-08-30T08:20:00.000Z",
 			expires_at: "2026-08-31T08:20:00.000Z",
 		});
@@ -59,8 +49,11 @@ describe("EmDash plugin Store authority", () => {
 		});
 
 		const states = await env.DB.prepare(
-			"SELECT COUNT(*) count FROM _plugin_state WHERE source = 'config' AND status = 'active' AND plugin_id LIKE 'supbrd-%'",
-		).first<{ count: number }>();
+			`SELECT COUNT(*) count FROM superboard_plugin_lifecycle
+			 WHERE instance_id = ? AND target = ? AND state = 'active'`,
+		)
+			.bind(scope.instance_id, scope.target)
+			.first<{ count: number }>();
 		expect(states?.count).toBe(18);
 		const manifests = await env.DB.prepare(
 			"SELECT COUNT(*) count FROM superboard_active_plugin_manifests WHERE plugin_id NOT LIKE '%*%'",
@@ -72,7 +65,7 @@ describe("EmDash plugin Store authority", () => {
 			.bind("vocostar")
 			.first<{ count: number }>();
 		expect(health?.count).toBe(18);
-		const fullLock = await loadActiveSuperBoardPluginLock(env.DB);
+		const fullLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		const fullPresentation = await composeUserFrontReleaseInput({
 			...releaseIdentifiers,
 			plugin_lock: fullLock,
@@ -95,12 +88,15 @@ describe("EmDash plugin Store authority", () => {
 			.bind(compatibleAnalyticsChecksum)
 			.first<{ artifact_checksum: string }>();
 		expect(previousAnalytics).not.toBeNull();
-		await env.DB.prepare(
-			"UPDATE superboard_active_plugin_manifests SET artifact_checksum = ? WHERE plugin_id = 'supbrd-plugmod-analytics'",
-		)
-			.bind(previousAnalytics!.artifact_checksum)
-			.run();
-		const rollingDeployLock = await loadActiveSuperBoardPluginLock(env.DB);
+		await env.DB.batch([
+			env.DB.prepare(
+				"UPDATE superboard_plugin_lifecycle SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(previousAnalytics!.artifact_checksum, scope.instance_id, scope.target),
+			env.DB.prepare(
+				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(previousAnalytics!.artifact_checksum, scope.instance_id, scope.target),
+		]);
+		const rollingDeployLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		expect(
 			rollingDeployLock.find(({ plugin_id: pluginId }) => pluginId === "supbrd-plugmod-analytics")
 				?.artifact_checksum,
@@ -123,27 +119,36 @@ describe("EmDash plugin Store authority", () => {
 		)
 			.bind(tamperedChecksum, tamperedChecksum, previousAnalytics!.artifact_checksum)
 			.run();
-		await env.DB.prepare(
-			"UPDATE superboard_active_plugin_manifests SET artifact_checksum = ? WHERE plugin_id = 'supbrd-plugmod-analytics'",
-		)
-			.bind(tamperedChecksum)
-			.run();
-		await expect(loadActiveSuperBoardPluginLock(env.DB)).rejects.toThrow(
+		await env.DB.batch([
+			env.DB.prepare(
+				"UPDATE superboard_plugin_lifecycle SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(tamperedChecksum, scope.instance_id, scope.target),
+			env.DB.prepare(
+				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(tamperedChecksum, scope.instance_id, scope.target),
+		]);
+		await expect(loadActiveSuperBoardPluginLock(env.DB, scope)).rejects.toThrow(
 			/PLUGIN_CATALOG_STORED_MANIFEST_INVALID:.*analytics/u,
 		);
 		const currentAnalytics = superBoardRuntimePluginCatalog().plugins.find(
 			({ manifest }) => manifest.plugin_id === "supbrd-plugmod-analytics",
 		)?.manifest.artifact_checksum;
-		await env.DB.prepare(
-			"UPDATE superboard_active_plugin_manifests SET artifact_checksum = ? WHERE plugin_id = 'supbrd-plugmod-analytics'",
-		)
-			.bind(currentAnalytics)
-			.run();
+		await env.DB.batch([
+			env.DB.prepare(
+				"UPDATE superboard_plugin_lifecycle SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(currentAnalytics, scope.instance_id, scope.target),
+			env.DB.prepare(
+				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
+			).bind(currentAnalytics, scope.instance_id, scope.target),
+		]);
 
 		await env.DB.prepare(
-			"DELETE FROM superboard_active_plugin_manifests WHERE plugin_id = 'supbrd-plugmod-marketing'",
-		).run();
-		const reducedLock = await loadActiveSuperBoardPluginLock(env.DB);
+			`DELETE FROM superboard_plugin_lifecycle
+			 WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-marketing'`,
+		)
+			.bind(scope.instance_id, scope.target)
+			.run();
+		const reducedLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		expect(reducedLock).toHaveLength(17);
 		expect(
 			reducedLock.some(({ plugin_id: pluginId }) => pluginId === "supbrd-plugmod-marketing"),

--- a/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
+++ b/apps/site/runtime-tests/plugin-store-authority.runtime.test.ts
@@ -25,6 +25,8 @@ import {
 } from "../src/lib/plugin-store-repository.js";
 import {
 	loadActiveSuperBoardPluginLock,
+	loadReleasableSuperBoardPluginLock,
+	reconcileSuperBoardPluginLifecycleForRelease,
 	superBoardRuntimePluginCatalog,
 	synchronizeSuperBoardPluginCatalog,
 } from "../src/lib/superboard-plugin-catalog.js";
@@ -36,6 +38,7 @@ describe("EmDash plugin Store authority", () => {
 		const scope = { instance_id: "vocostar", target: "local" as const };
 		const receipt = await synchronizeSuperBoardPluginCatalog(env.DB, {
 			...scope,
+			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:20:00.000Z",
 			expires_at: "2026-08-31T08:20:00.000Z",
 		});
@@ -45,26 +48,37 @@ describe("EmDash plugin Store authority", () => {
 			receipt.installed.find(({ plugin_id }) => plugin_id === "supbrd-plug-user"),
 		).toMatchObject({
 			plugin_version: "1.3.0",
-			status: "active",
+			status: "installed",
 		});
 
 		const states = await env.DB.prepare(
 			`SELECT COUNT(*) count FROM superboard_plugin_lifecycle
-			 WHERE instance_id = ? AND target = ? AND state = 'active'`,
+			 WHERE instance_id = ? AND target = ? AND state = 'installed'`,
 		)
 			.bind(scope.instance_id, scope.target)
 			.first<{ count: number }>();
 		expect(states?.count).toBe(18);
-		const manifests = await env.DB.prepare(
-			"SELECT COUNT(*) count FROM superboard_active_plugin_manifests WHERE plugin_id NOT LIKE '%*%'",
-		).first<{ count: number }>();
-		expect(manifests?.count).toBe(18);
 		const health = await env.DB.prepare(
-			"SELECT COUNT(*) count FROM superboard_dependency_health WHERE instance_id = ? AND status = 'ready'",
+			`SELECT COUNT(*) count FROM superboard_plugin_runtime_health
+			 WHERE instance_id = ? AND target = ? AND status = 'ready'`,
 		)
-			.bind("vocostar")
+			.bind(scope.instance_id, scope.target)
 			.first<{ count: number }>();
 		expect(health?.count).toBe(18);
+		const candidateLock = await loadReleasableSuperBoardPluginLock(env.DB, scope);
+		await activateReleasePointer(
+			env.DB,
+			scope.instance_id,
+			"01J00000000000000000000501",
+			candidateLock,
+			"2026-08-30T08:25:00.000Z",
+		);
+		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+			...scope,
+			release_id: "01J00000000000000000000501",
+			plugin_lock: candidateLock,
+			activated_at: "2026-08-30T08:25:00.000Z",
+		});
 		const fullLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
 		const fullPresentation = await composeUserFrontReleaseInput({
 			...releaseIdentifiers,
@@ -96,39 +110,8 @@ describe("EmDash plugin Store authority", () => {
 				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
 			).bind(previousAnalytics!.artifact_checksum, scope.instance_id, scope.target),
 		]);
-		const rollingDeployLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
-		expect(
-			rollingDeployLock.find(({ plugin_id: pluginId }) => pluginId === "supbrd-plugmod-analytics")
-				?.artifact_checksum,
-		).toBe(previousAnalytics!.artifact_checksum);
-		await expect(
-			composeUserFrontReleaseInput({
-				...releaseIdentifiers,
-				plugin_lock: rollingDeployLock,
-			}),
-		).rejects.toThrow(/PLUGIN_LOCK_MANIFEST_MISMATCH:.*analytics/u);
-		const tamperedChecksum = `sha256:${"f".repeat(64)}`;
-		await env.DB.prepare(
-			`INSERT INTO superboard_plugin_manifest_artifacts
-			 (artifact_checksum, plugin_id, manifest_json, installed_at)
-			 SELECT ?, plugin_id,
-			        json_set(manifest_json, '$.artifact_checksum', ?, '$.publisher', 'tampered'),
-			        installed_at
-			 FROM superboard_plugin_manifest_artifacts
-			 WHERE artifact_checksum = ?`,
-		)
-			.bind(tamperedChecksum, tamperedChecksum, previousAnalytics!.artifact_checksum)
-			.run();
-		await env.DB.batch([
-			env.DB.prepare(
-				"UPDATE superboard_plugin_lifecycle SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
-			).bind(tamperedChecksum, scope.instance_id, scope.target),
-			env.DB.prepare(
-				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
-			).bind(tamperedChecksum, scope.instance_id, scope.target),
-		]);
 		await expect(loadActiveSuperBoardPluginLock(env.DB, scope)).rejects.toThrow(
-			/PLUGIN_CATALOG_STORED_MANIFEST_INVALID:.*analytics/u,
+			/PLUGIN_INSTALLATION_PLAN_CONTRACT_MISSING:.*analytics/u,
 		);
 		const currentAnalytics = superBoardRuntimePluginCatalog().plugins.find(
 			({ manifest }) => manifest.plugin_id === "supbrd-plugmod-analytics",
@@ -141,6 +124,11 @@ describe("EmDash plugin Store authority", () => {
 				"UPDATE superboard_plugin_runtime_health SET artifact_checksum = ? WHERE instance_id = ? AND target = ? AND plugin_id = 'supbrd-plugmod-analytics'",
 			).bind(currentAnalytics, scope.instance_id, scope.target),
 		]);
+		const restoredLock = await loadActiveSuperBoardPluginLock(env.DB, scope);
+		expect(
+			restoredLock.find(({ plugin_id: pluginId }) => pluginId === "supbrd-plugmod-analytics")
+				?.artifact_checksum,
+		).toBe(currentAnalytics);
 
 		await env.DB.prepare(
 			`DELETE FROM superboard_plugin_lifecycle
@@ -167,6 +155,7 @@ describe("EmDash plugin Store authority", () => {
 	test("installs the exact compiled user plugin and publishes bounded dependency health", async () => {
 		const receipt = await installCompiledUserPlugin(env.DB, {
 			instance_id: "vocostar",
+			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:30:00.000Z",
 			expires_at: "2026-08-30T09:30:00.000Z",
 		});
@@ -175,18 +164,18 @@ describe("EmDash plugin Store authority", () => {
 			plugin_version: userPluginManifest.plugin_version,
 			artifact_checksum: userPluginManifest.artifact_checksum,
 			dependency_id: "dependency.supbrd_plug_user",
-			status: "ready",
+			status: "installed",
 		});
 		expect(receipt.evidence_checksum).toMatch(/^sha256:[a-f0-9]{64}$/u);
 
 		const installed = await env.DB.prepare(
 			`SELECT artifact.artifact_checksum, artifact.manifest_json
-			 FROM superboard_active_plugin_manifests active
+			 FROM superboard_plugin_installation_items item
 			 JOIN superboard_plugin_manifest_artifacts artifact
-			   ON artifact.artifact_checksum = active.artifact_checksum
-			 WHERE active.plugin_id = ? AND active.artifact_checksum = ?`,
+			   ON artifact.artifact_checksum = item.artifact_checksum
+			 WHERE item.plan_id = ? AND item.plugin_id = ? AND item.state = 'installed'`,
 		)
-			.bind(userPluginManifest.plugin_id, userPluginManifest.artifact_checksum)
+			.bind(receipt.plan_id, userPluginManifest.plugin_id)
 			.first<{ artifact_checksum: string; manifest_json: string }>();
 		expect(installed?.artifact_checksum).toBe(userPluginManifest.artifact_checksum);
 		expect(JSON.parse(installed?.manifest_json ?? "{}")).toMatchObject({
@@ -194,9 +183,10 @@ describe("EmDash plugin Store authority", () => {
 		});
 
 		const health = await env.DB.prepare(
-			"SELECT status, evidence_checksum, expires_at FROM superboard_dependency_health WHERE instance_id = ? AND dependency_id = ?",
+			`SELECT status, evidence_checksum, expires_at FROM superboard_plugin_runtime_health
+			 WHERE instance_id = ? AND target = 'local' AND plugin_id = ?`,
 		)
-			.bind("vocostar", "dependency.supbrd_plug_user")
+			.bind("vocostar", userPluginManifest.plugin_id)
 			.first();
 		expect(health).toEqual({
 			status: "ready",
@@ -274,6 +264,7 @@ describe("EmDash plugin Store authority", () => {
 	test("commits compatibility mutations before transient execution and replays receipts", async () => {
 		await synchronizeSuperBoardPluginCatalog(env.DB, {
 			instance_id: "vocostar",
+			approved_by: "operator-1",
 			checked_at: "2026-08-30T08:20:00.000Z",
 			expires_at: "2026-08-31T08:20:00.000Z",
 		});
@@ -343,6 +334,7 @@ describe("EmDash plugin Store authority", () => {
 	test("keeps the compatibility Worker transient behind the repository-first gateway", async () => {
 		await synchronizeSuperBoardPluginCatalog(env.DB, {
 			instance_id: "vocostar",
+			approved_by: "operator-1",
 			checked_at: "2026-08-30T09:10:00.000Z",
 			expires_at: "2026-08-31T09:10:00.000Z",
 		});
@@ -543,12 +535,36 @@ describe("EmDash plugin Store authority", () => {
 	});
 
 	test("rehearses encrypted idempotent authority for every declared domain Store", async () => {
+		await synchronizeSuperBoardPluginCatalog(env.DB, {
+			instance_id: "parity-all",
+			target: "local",
+			approved_by: "operator-1",
+			checked_at: "2026-08-30T02:00:00.000Z",
+			expires_at: "2026-08-31T02:00:00.000Z",
+		});
+		const parityScope = { instance_id: "parity-all", target: "local" as const };
+		const parityLock = await loadReleasableSuperBoardPluginLock(env.DB, parityScope);
+		await activateReleasePointer(
+			env.DB,
+			parityScope.instance_id,
+			"01J00000000000000000000511",
+			parityLock,
+			"2026-08-30T02:01:00.000Z",
+		);
+		await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+			...parityScope,
+			release_id: "01J00000000000000000000511",
+			plugin_lock: parityLock,
+			activated_at: "2026-08-30T02:01:00.000Z",
+		});
 		const encryptionKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
 			"encrypt",
 			"decrypt",
 		]);
 		let storeCount = 0;
-		for (const { manifest } of topology.plugins) {
+		for (const { manifest } of topology.plugins.filter(
+			({ manifest }) => !manifest.plugin_id.includes("*"),
+		)) {
 			for (const store of manifest.stores) {
 				storeCount += 1;
 				const entityId = `fixture-${storeCount}`;
@@ -593,6 +609,55 @@ describe("EmDash plugin Store authority", () => {
 		expect(storeCount).toBeGreaterThan(19);
 	});
 });
+
+async function activateReleasePointer(
+	db: D1Database,
+	instanceId: string,
+	releaseId: string,
+	pluginLock: readonly unknown[],
+	activatedAt: string,
+) {
+	await db.batch([
+		db
+			.prepare(
+				`INSERT INTO superboard_release_signing_keys
+				 (kid, public_jwk, status, created_at, retired_at)
+				 VALUES ('plugin-authority-test-key', '{}', 'active', ?, NULL)
+				 ON CONFLICT(kid) DO NOTHING`,
+			)
+			.bind(activatedAt),
+		db
+			.prepare(
+				`INSERT INTO superboard_front_release_candidates
+				 (candidate_id, instance_id, release_id, release_json, content_checksum,
+				  validation_set_checksum, signing_kid, status, approval_json, created_at, approved_at)
+				 VALUES (?, ?, ?, ?, 'sha256:test', 'sha256:test',
+				         'plugin-authority-test-key', 'approved', '{}', ?, ?)`,
+			)
+			.bind(
+				`${releaseId}-candidate`,
+				instanceId,
+				releaseId,
+				JSON.stringify({ payload: { plugin_lock: pluginLock } }),
+				activatedAt,
+				activatedAt,
+			),
+		db
+			.prepare(
+				`INSERT INTO superboard_front_active_releases
+				 (instance_id, active_release_id, previous_release_id, pointer_revision,
+				  activation_id, activated_at)
+				 VALUES (?, ?, NULL, 1, ?, ?)
+				 ON CONFLICT(instance_id) DO UPDATE SET
+				   previous_release_id = superboard_front_active_releases.active_release_id,
+				   active_release_id = excluded.active_release_id,
+				   pointer_revision = superboard_front_active_releases.pointer_revision + 1,
+				   activation_id = excluded.activation_id,
+				   activated_at = excluded.activated_at`,
+			)
+			.bind(instanceId, releaseId, `${releaseId}-activation`, activatedAt),
+	]);
+}
 
 const releaseIdentifiers = {
 	instance_id: "vocostar",

--- a/apps/site/src/lib/operator-api-proxy.ts
+++ b/apps/site/src/lib/operator-api-proxy.ts
@@ -5,12 +5,14 @@ import {
 	resolveRepositoryCommandScope,
 } from "./plugin-command-authority.js";
 import { importPluginStoreEncryptionKey } from "./plugin-store-repository.js";
+import { resolveSuperBoardPluginTarget } from "./superboard-plugin-catalog.js";
 
 interface OperatorApiProxyEnv {
 	API_SERVICE?: { fetch(request: Request): Promise<Response> };
 	SITE_OPERATOR_BRIDGE_TOKEN?: string;
 	DB?: D1Database;
 	SUPERBOARD_INSTANCE_ID?: string;
+	SUPERBOARD_ENVIRONMENT?: string;
 	SUPERBOARD_PLUGIN_STORE_ENCRYPTION_KEY?: string;
 }
 
@@ -114,6 +116,7 @@ async function executeRepositoryFirstCommand(input: {
 		const accepted = await beginRepositoryCommand(db, {
 			operation_id: operationId,
 			instance_id: instanceId,
+			target: resolveSuperBoardPluginTarget(input.env.SUPERBOARD_ENVIRONMENT ?? "local"),
 			project_ref: scope.project_ref,
 			plugin_id: scope.plugin_id,
 			command_id: input.request_headers.get("X-SuperBoard-Command-Id")?.trim() || undefined,

--- a/apps/site/src/lib/plugin-command-authority.ts
+++ b/apps/site/src/lib/plugin-command-authority.ts
@@ -39,7 +39,7 @@ export interface RepositoryCommandInput {
 
 export async function beginRepositoryCommand(db: D1Database, input: RepositoryCommandInput) {
 	assertCommandInput(input);
-	await assertActiveCommandContract(db, input.plugin_id, input.command_id);
+	await assertActiveCommandContract(db, input.instance_id, input.plugin_id, input.command_id);
 	const pathChecksum = await sha256(new TextEncoder().encode(input.request_path));
 	const requestChecksum = await sha256(
 		new TextEncoder().encode(
@@ -153,7 +153,8 @@ export function resolveRepositoryCommandScope(url: URL): {
 	const pathname = url.pathname;
 	const projectRef =
 		pathname.match(/\/(\d+-(?:test|prod))(?:\/|$)/u)?.[1] ??
-		(url.searchParams.get("project_ref")?.match(projectRefPattern)?.[0] ?? "instance-wide");
+		url.searchParams.get("project_ref")?.match(projectRefPattern)?.[0] ??
+		"instance-wide";
 	const pluginId = inferPluginId(pathname);
 	return {
 		plugin_id: pluginId,
@@ -170,6 +171,7 @@ export function assertIdempotencyKey(value: string | null): string {
 
 async function assertActiveCommandContract(
 	db: D1Database,
+	instanceId: string,
 	pluginId: string,
 	commandId: string | undefined,
 ) {
@@ -177,16 +179,19 @@ async function assertActiveCommandContract(
 	const active = await db
 		.prepare(
 			`SELECT artifact.manifest_json
-			 FROM superboard_active_plugin_manifests active
+			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
-			   ON artifact.artifact_checksum = active.artifact_checksum
-			 WHERE active.plugin_id = ? AND artifact.plugin_id = active.plugin_id`,
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.plugin_id = ?
+			   AND lifecycle.state = 'active' AND artifact.plugin_id = lifecycle.plugin_id`,
 		)
-		.bind(pluginId)
+		.bind(instanceId, pluginId)
 		.first<{ manifest_json: string }>();
 	if (!active) throw new Error("PLUGIN_MANIFEST_NOT_ACTIVE");
 	if (!commandId) return;
-	const manifest = JSON.parse(active.manifest_json) as { commands?: Array<{ command_id?: string }> };
+	const manifest = JSON.parse(active.manifest_json) as {
+		commands?: Array<{ command_id?: string }>;
+	};
 	if (!manifest.commands?.some(({ command_id: value }) => value === commandId)) {
 		throw new Error("PLUGIN_COMMAND_NOT_DECLARED");
 	}
@@ -308,7 +313,10 @@ async function encryptBytes(key: CryptoKey, bytes: Uint8Array): Promise<Encrypte
 	};
 }
 
-async function decryptBytes(key: CryptoKey, payload: EncryptedBytes): Promise<Uint8Array<ArrayBuffer>> {
+async function decryptBytes(
+	key: CryptoKey,
+	payload: EncryptedBytes,
+): Promise<Uint8Array<ArrayBuffer>> {
 	const plaintext = await crypto.subtle.decrypt(
 		{ name: "AES-GCM", iv: base64ToBytes(payload.iv) },
 		key,

--- a/apps/site/src/lib/plugin-command-authority.ts
+++ b/apps/site/src/lib/plugin-command-authority.ts
@@ -26,6 +26,7 @@ interface CommandOperationRow {
 export interface RepositoryCommandInput {
 	operation_id: string;
 	instance_id: string;
+	target?: "local" | "development" | "production";
 	project_ref: string;
 	plugin_id: string;
 	command_id?: string;
@@ -39,7 +40,13 @@ export interface RepositoryCommandInput {
 
 export async function beginRepositoryCommand(db: D1Database, input: RepositoryCommandInput) {
 	assertCommandInput(input);
-	await assertActiveCommandContract(db, input.instance_id, input.plugin_id, input.command_id);
+	await assertActiveCommandContract(
+		db,
+		input.instance_id,
+		input.target ?? "local",
+		input.plugin_id,
+		input.command_id,
+	);
 	const pathChecksum = await sha256(new TextEncoder().encode(input.request_path));
 	const requestChecksum = await sha256(
 		new TextEncoder().encode(
@@ -172,6 +179,7 @@ export function assertIdempotencyKey(value: string | null): string {
 async function assertActiveCommandContract(
 	db: D1Database,
 	instanceId: string,
+	target: "local" | "development" | "production",
 	pluginId: string,
 	commandId: string | undefined,
 ) {
@@ -182,10 +190,10 @@ async function assertActiveCommandContract(
 			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
 			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
-			 WHERE lifecycle.instance_id = ? AND lifecycle.plugin_id = ?
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ? AND lifecycle.plugin_id = ?
 			   AND lifecycle.state = 'active' AND artifact.plugin_id = lifecycle.plugin_id`,
 		)
-		.bind(instanceId, pluginId)
+		.bind(instanceId, target, pluginId)
 		.first<{ manifest_json: string }>();
 	if (!active) throw new Error("PLUGIN_MANIFEST_NOT_ACTIVE");
 	if (!commandId) return;

--- a/apps/site/src/lib/plugin-store-repository.ts
+++ b/apps/site/src/lib/plugin-store-repository.ts
@@ -40,15 +40,17 @@ interface StoreRecordRow {
 
 export async function putPluginStoreRecord(db: D1Database, input: StoreRecordInput) {
 	assertPlugin(input.plugin_id);
+	const instanceId = resolveInstanceAlias(input);
 	const installed = await db
 		.prepare(
 			`SELECT artifact.manifest_json, artifact.artifact_checksum
-			 FROM superboard_active_plugin_manifests AS active
+			 FROM superboard_plugin_lifecycle AS lifecycle
 			 JOIN superboard_plugin_manifest_artifacts AS artifact
-			   ON artifact.artifact_checksum = active.artifact_checksum
-			 WHERE active.plugin_id = ? AND artifact.plugin_id = active.plugin_id`,
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.plugin_id = ?
+			   AND lifecycle.state = 'active' AND artifact.plugin_id = lifecycle.plugin_id`,
 		)
-		.bind(input.plugin_id)
+		.bind(instanceId, input.plugin_id)
 		.first<{ manifest_json: string; artifact_checksum: string }>();
 	if (!installed) throw new Error("PLUGIN_MANIFEST_NOT_ACTIVE");
 	const manifest: unknown = JSON.parse(installed.manifest_json);
@@ -69,7 +71,6 @@ export async function putPluginStoreRecord(db: D1Database, input: StoreRecordInp
 	if (!input.store_id.startsWith(`${input.plugin_id}.store.`)) {
 		throw new Error("STORE_NAMESPACE_REJECTED");
 	}
-	const instanceId = resolveInstanceAlias(input);
 	const projectRef = normalizeProjectRef(input.project_ref);
 	const storedEntityId = qualifyEntityId(projectRef, input.entity_id);
 	const canonicalPayload = canonicalizeReleasePayload(input.payload);

--- a/apps/site/src/lib/plugin-store-repository.ts
+++ b/apps/site/src/lib/plugin-store-repository.ts
@@ -11,6 +11,7 @@ interface StoreRecordInput {
 	plugin_id: string;
 	store_id: string;
 	instance_id?: string;
+	target?: "local" | "development" | "production";
 	projectId?: string;
 	pid?: string;
 	project_ref?: string;
@@ -47,10 +48,10 @@ export async function putPluginStoreRecord(db: D1Database, input: StoreRecordInp
 			 FROM superboard_plugin_lifecycle AS lifecycle
 			 JOIN superboard_plugin_manifest_artifacts AS artifact
 			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
-			 WHERE lifecycle.instance_id = ? AND lifecycle.plugin_id = ?
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ? AND lifecycle.plugin_id = ?
 			   AND lifecycle.state = 'active' AND artifact.plugin_id = lifecycle.plugin_id`,
 		)
-		.bind(instanceId, input.plugin_id)
+		.bind(instanceId, input.target ?? "local", input.plugin_id)
 		.first<{ manifest_json: string; artifact_checksum: string }>();
 	if (!installed) throw new Error("PLUGIN_MANIFEST_NOT_ACTIVE");
 	const manifest: unknown = JSON.parse(installed.manifest_json);

--- a/apps/site/src/lib/site-env.ts
+++ b/apps/site/src/lib/site-env.ts
@@ -4,6 +4,8 @@ export interface SuperBoardSiteEnv extends Cloudflare.Env {
 	SUPERBOARD_RELEASE_PRIVATE_JWK?: string;
 	SUPERBOARD_API_URL?: string;
 	SUPERBOARD_ENVIRONMENT: string;
+	SUPERBOARD_PLUGIN_IDS: string;
+	TARGET_ARTIFACT_CHECKSUM: string;
 }
 
 export function getSiteEnv(): SuperBoardSiteEnv {

--- a/apps/site/src/lib/site-env.ts
+++ b/apps/site/src/lib/site-env.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers";
 export interface SuperBoardSiteEnv extends Cloudflare.Env {
 	SUPERBOARD_RELEASE_PRIVATE_JWK?: string;
 	SUPERBOARD_API_URL?: string;
+	SUPERBOARD_ENVIRONMENT: string;
 }
 
 export function getSiteEnv(): SuperBoardSiteEnv {

--- a/apps/site/src/lib/superboard-plugin-catalog.ts
+++ b/apps/site/src/lib/superboard-plugin-catalog.ts
@@ -9,9 +9,23 @@ import { userPluginManifest, validateUserPluginManifest } from "@superboard/supb
 import topologyJson from "../../../../config/emdash-plugin-topology.json";
 import compatibilityJson from "../../../../config/superboard-plugin-compatibility.json";
 
+export type SuperBoardPluginTarget = "local" | "development" | "production";
+export type SuperBoardPluginLifecycleState =
+	| "available"
+	| "staged"
+	| "installed"
+	| "active"
+	| "draining"
+	| "disabled"
+	| "quarantined"
+	| "purged";
+
 interface WorkerDescriptor {
 	deployment_status: "ready" | "not_ready";
 	checksum: string;
+	authoritative_writes: boolean;
+	store_ids: string[];
+	[key: string]: unknown;
 }
 
 interface TopologyPlugin {
@@ -19,11 +33,78 @@ interface TopologyPlugin {
 	worker_descriptor: WorkerDescriptor | null;
 }
 
+interface PluginScope {
+	instance_id: string;
+	target: SuperBoardPluginTarget;
+}
+
+interface PlanInput extends PluginScope {
+	plan_id: string;
+	checked_at: string;
+	expires_at: string;
+	plugin_ids?: readonly string[];
+}
+
+interface DerivedPluginContract {
+	stores: Array<{ store_id: string; schema_version: string; migrations_checksum: string }>;
+	capabilities: string[];
+	capability_approval_checksum: string;
+	settings_checksum: string;
+	contributions_checksum: string;
+	migrations_checksum: string;
+	worker_descriptor_checksum: string | null;
+	worker_status: "ready" | "unavailable";
+	plugin_lock: {
+		plugin_id: string;
+		version: string;
+		artifact_checksum: string;
+		native: boolean;
+	};
+}
+
+interface PlannedPlugin {
+	manifest: SuperBoardPluginManifest;
+	worker_descriptor: WorkerDescriptor | null;
+	derived: DerivedPluginContract;
+	derived_contract_checksum: string;
+	health_evidence_checksum: string;
+}
+
 const topology = topologyJson as unknown as { plugins: TopologyPlugin[] };
 const compatibility = compatibilityJson as {
 	artifacts: Record<string, { plugin_id: string; manifest_checksum: string }>;
 };
-const PLUGIN_ID_PREFIX_PATTERN = /^supbrd-(?:plug|plugmod)-/u;
+const MISSING_PLUGIN_STATE_TABLE_PATTERN = /no such table:\s*_plugin_state/iu;
+const TARGETS = new Set<SuperBoardPluginTarget>(["local", "development", "production"]);
+const LIFECYCLE_TRANSITIONS: Record<
+	SuperBoardPluginLifecycleState,
+	readonly SuperBoardPluginLifecycleState[]
+> = {
+	available: ["staged"],
+	staged: ["installed", "quarantined"],
+	installed: ["active", "quarantined"],
+	active: ["draining", "quarantined"],
+	draining: ["disabled", "quarantined"],
+	disabled: ["staged", "quarantined"],
+	quarantined: ["staged", "purged"],
+	purged: ["available"],
+};
+
+export function resolveSuperBoardPluginTarget(value: unknown): SuperBoardPluginTarget {
+	if (typeof value === "string" && TARGETS.has(value as SuperBoardPluginTarget)) {
+		return value as SuperBoardPluginTarget;
+	}
+	throw new TypeError("Plugin lifecycle requires a valid target");
+}
+
+export function resolveSuperBoardPluginLifecycleState(
+	value: unknown,
+): SuperBoardPluginLifecycleState {
+	if (typeof value === "string" && value in LIFECYCLE_TRANSITIONS) {
+		return value as SuperBoardPluginLifecycleState;
+	}
+	throw new TypeError("Plugin lifecycle requires a valid state");
+}
 
 export interface SuperBoardRuntimePlugin {
 	manifest: SuperBoardPluginManifest;
@@ -39,12 +120,6 @@ export function superBoardRuntimePluginCatalog(): {
 	for (const entry of topology.plugins) {
 		if (entry.manifest.plugin_id.includes("*")) {
 			templates.push(entry.manifest.plugin_id);
-			continue;
-		}
-		if (
-			entry.manifest.plugin_kind === "module" &&
-			entry.worker_descriptor?.deployment_status !== "ready"
-		) {
 			continue;
 		}
 		plugins.push({
@@ -63,44 +138,69 @@ export function superBoardRuntimePluginCatalog(): {
 	};
 }
 
-export async function synchronizeSuperBoardPluginCatalog(
-	db: D1Database,
-	input: { instance_id: string; checked_at: string; expires_at: string },
-) {
-	if (
-		!input.instance_id ||
-		!isCanonicalTimestamp(input.checked_at) ||
-		!isCanonicalTimestamp(input.expires_at) ||
-		Date.parse(input.expires_at) <= Date.parse(input.checked_at)
-	) {
-		throw new TypeError("Plugin catalogue synchronization requires a bounded validity window");
-	}
-	const catalog = superBoardRuntimePluginCatalog();
-	const statements: D1PreparedStatement[] = [];
-	const installed = [];
-	for (const { manifest, worker_descriptor: workerDescriptor } of catalog.plugins) {
-		const verification =
-			manifest.plugin_id === userPluginManifest.plugin_id
-				? await validateUserPluginManifest(manifest)
-				: await verifySuperBoardPluginManifest(manifest);
-		if (!verification.valid) {
-			throw new Error(
-				`${manifest.plugin_id} manifest is invalid: ${verification.errors.join(",")}`,
-			);
+export async function installSuperBoardPluginCatalog(db: D1Database, input: PlanInput) {
+	assertPlanInput(input);
+	const existing = await db
+		.prepare(
+			`SELECT instance_id, target FROM superboard_plugin_installation_plans
+			 WHERE plan_id = ?`,
+		)
+		.bind(input.plan_id)
+		.first<{ instance_id: string; target: SuperBoardPluginTarget }>();
+	if (existing) {
+		if (existing.instance_id !== input.instance_id || existing.target !== input.target) {
+			throw new Error("PLUGIN_INSTALLATION_PLAN_SCOPE_MISMATCH");
 		}
-		const dependencyId = `dependency.${manifest.plugin_id.replaceAll("-", "_")}`;
-		const evidenceChecksum = await sha256Canonical({
-			domain: "superboard.plugin_runtime_health.v1",
-			instance_id: input.instance_id,
-			plugin_id: manifest.plugin_id,
-			plugin_version: manifest.plugin_version,
-			artifact_checksum: manifest.artifact_checksum,
-			worker_descriptor_checksum: workerDescriptor?.checksum ?? null,
-			checked_at: input.checked_at,
-			expires_at: input.expires_at,
-		});
-		const displayName = displayPluginName(manifest.plugin_id);
-		const description = `${manifest.plugin_kind === "full" ? "Full" : "Module"} SuperBoard · ${manifest.stores.length} Stores · ${manifest.commands.length} commands`;
+		return loadInstallationPlanReceipt(db, input.plan_id);
+	}
+
+	const catalog = superBoardRuntimePluginCatalog();
+	const selectedIds = input.plugin_ids ? new Set(input.plugin_ids) : null;
+	const selected = selectedIds
+		? catalog.plugins.filter(({ manifest }) => selectedIds.has(manifest.plugin_id))
+		: catalog.plugins;
+	if (selected.length === 0 || (selectedIds && selected.length !== selectedIds.size)) {
+		throw new Error("PLUGIN_INSTALLATION_PLAN_UNKNOWN_PLUGIN");
+	}
+	const planned = await Promise.all(selected.map((plugin) => derivePluginContract(plugin, input)));
+	const catalogChecksum = await sha256Canonical(planned.map(({ derived }) => derived.plugin_lock));
+	const unavailable = planned.filter(({ derived }) => derived.worker_status !== "ready");
+	const currentRows = await db
+		.prepare(
+			`SELECT plugin_id, state FROM superboard_plugin_lifecycle
+			 WHERE instance_id = ? AND target = ?`,
+		)
+		.bind(input.instance_id, input.target)
+		.all<{ plugin_id: string; state: SuperBoardPluginLifecycleState }>();
+	const currentStates = new Map(currentRows.results.map((row) => [row.plugin_id, row.state]));
+	for (const { manifest } of planned) {
+		const state = currentStates.get(manifest.plugin_id);
+		if (state === "draining" || state === "quarantined") {
+			throw new Error(`PLUGIN_INSTALLATION_PLAN_STATE_CONFLICT:${manifest.plugin_id}:${state}`);
+		}
+	}
+
+	const failed = unavailable.length > 0;
+	const statements: D1PreparedStatement[] = [
+		db
+			.prepare(
+				`INSERT INTO superboard_plugin_installation_plans
+				 (plan_id, instance_id, target, status, catalog_checksum, plugin_count,
+				  created_at, completed_at, failure_json)
+				 VALUES (?, ?, ?, 'installing', ?, ?, ?, NULL, NULL)`,
+			)
+			.bind(
+				input.plan_id,
+				input.instance_id,
+				input.target,
+				catalogChecksum,
+				planned.length,
+				input.checked_at,
+			),
+	];
+	for (const plugin of planned) {
+		const { manifest, derived } = plugin;
+		const currentState = currentStates.get(manifest.plugin_id);
 		statements.push(
 			db
 				.prepare(
@@ -117,6 +217,216 @@ export async function synchronizeSuperBoardPluginCatalog(
 				),
 			db
 				.prepare(
+					`INSERT INTO superboard_plugin_installation_items
+					 (plan_id, plugin_id, artifact_checksum, state, derived_contract_json,
+					  derived_contract_checksum, health_status)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.bind(
+					input.plan_id,
+					manifest.plugin_id,
+					manifest.artifact_checksum,
+					failed ? (derived.worker_status === "ready" ? "staged" : "failed") : "installed",
+					canonicalizeReleasePayload(derived),
+					plugin.derived_contract_checksum,
+					derived.worker_status,
+				),
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_runtime_health
+					 (instance_id, target, plugin_id, artifact_checksum, status,
+					  evidence_checksum, checked_at, expires_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(instance_id, target, plugin_id) DO UPDATE SET
+					   artifact_checksum = excluded.artifact_checksum,
+					   status = excluded.status,
+					   evidence_checksum = excluded.evidence_checksum,
+					   checked_at = excluded.checked_at,
+					   expires_at = excluded.expires_at`,
+				)
+				.bind(
+					input.instance_id,
+					input.target,
+					manifest.plugin_id,
+					manifest.artifact_checksum,
+					derived.worker_status,
+					plugin.health_evidence_checksum,
+					input.checked_at,
+					input.expires_at,
+				),
+		);
+
+		const nextState: SuperBoardPluginLifecycleState = failed ? "staged" : "installed";
+		statements.push(
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_lifecycle
+					 (instance_id, target, plugin_id, artifact_checksum, state, plan_id,
+					  state_changed_at, reason)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, 'installation plan')
+					 ON CONFLICT(instance_id, target, plugin_id) DO UPDATE SET
+					   artifact_checksum = excluded.artifact_checksum,
+					   state = excluded.state,
+					   plan_id = excluded.plan_id,
+					   state_changed_at = excluded.state_changed_at,
+					   reason = excluded.reason
+					 WHERE superboard_plugin_lifecycle.state IN
+					   ('available', 'staged', 'installed', 'disabled', 'purged')`,
+				)
+				.bind(
+					input.instance_id,
+					input.target,
+					manifest.plugin_id,
+					manifest.artifact_checksum,
+					nextState,
+					input.plan_id,
+					input.checked_at,
+				),
+			...lifecycleInstallationEvents(db, {
+				...input,
+				plugin_id: manifest.plugin_id,
+				artifact_checksum: manifest.artifact_checksum,
+				current_state: currentState,
+				to_state: nextState,
+			}),
+		);
+	}
+	statements.push(
+		db
+			.prepare(
+				`UPDATE superboard_plugin_installation_plans
+				 SET status = ?, completed_at = ?, failure_json = ?
+				 WHERE plan_id = ? AND status = 'installing'`,
+			)
+			.bind(
+				failed ? "failed" : "installed",
+				input.checked_at,
+				failed
+					? canonicalizeReleasePayload({
+							code: "PLUGIN_INSTALLATION_PLAN_NOT_READY",
+							plugins: unavailable.map(({ manifest }) => manifest.plugin_id),
+						})
+					: null,
+				input.plan_id,
+			),
+	);
+	await db.batch(statements);
+	await writeEmDashPluginStates(
+		db,
+		planned
+			.map(({ manifest }) => ({
+				plugin_id: manifest.plugin_id,
+				version: manifest.plugin_version,
+			}))
+			.filter(({ plugin_id: pluginId }) => currentStates.get(pluginId) !== "active"),
+		"inactive",
+		input.checked_at,
+	);
+	if (failed) {
+		throw new Error(
+			`PLUGIN_INSTALLATION_PLAN_NOT_READY:${unavailable.map(({ manifest }) => manifest.plugin_id).join(",")}`,
+		);
+	}
+	return loadInstallationPlanReceipt(db, input.plan_id);
+}
+
+export async function activateSuperBoardPluginInstallationPlan(
+	db: D1Database,
+	input: PluginScope & { plan_id: string; changed_at: string },
+) {
+	assertScope(input);
+	if (!input.plan_id || !isCanonicalTimestamp(input.changed_at)) {
+		throw new TypeError("Plugin activation requires a plan and canonical timestamp");
+	}
+	const plan = await loadInstallationPlanReceipt(db, input.plan_id);
+	if (plan.instance_id !== input.instance_id || plan.target !== input.target) {
+		throw new Error("PLUGIN_INSTALLATION_PLAN_SCOPE_MISMATCH");
+	}
+	if (plan.status === "active") {
+		return { ...input, status: "active" as const, plugin_count: plan.plugin_count };
+	}
+	if (plan.status !== "installed") throw new Error("PLUGIN_INSTALLATION_PLAN_NOT_INSTALLED");
+	const rows = await db
+		.prepare(
+			`SELECT item.plugin_id, item.artifact_checksum, item.health_status,
+			        health.evidence_checksum, health.expires_at, lifecycle.state,
+			        json_extract(item.derived_contract_json, '$.plugin_lock.version') AS plugin_version
+			 FROM superboard_plugin_installation_items item
+			 JOIN superboard_plugin_runtime_health health
+			   ON health.instance_id = ? AND health.target = ?
+			  AND health.plugin_id = item.plugin_id
+			 JOIN superboard_plugin_lifecycle lifecycle
+			   ON lifecycle.instance_id = ? AND lifecycle.target = ?
+			  AND lifecycle.plugin_id = item.plugin_id
+			 WHERE item.plan_id = ?
+			 ORDER BY item.plugin_id`,
+		)
+		.bind(input.instance_id, input.target, input.instance_id, input.target, input.plan_id)
+		.all<{
+			plugin_id: string;
+			artifact_checksum: string;
+			health_status: "ready" | "unavailable";
+			evidence_checksum: string;
+			expires_at: string;
+			state: SuperBoardPluginLifecycleState;
+			plugin_version: string;
+		}>();
+	if (rows.results.length !== plan.plugin_count)
+		throw new Error("PLUGIN_INSTALLATION_PLAN_INCOMPLETE");
+	for (const row of rows.results) {
+		if (
+			row.health_status !== "ready" ||
+			Date.parse(row.expires_at) <= Date.parse(input.changed_at)
+		) {
+			throw new Error(`PLUGIN_ACTIVATION_HEALTH_NOT_READY:${row.plugin_id}`);
+		}
+		if (row.state !== "installed" && row.state !== "active") {
+			throw new Error(`PLUGIN_ACTIVATION_STATE_INVALID:${row.plugin_id}:${row.state}`);
+		}
+	}
+
+	const statements: D1PreparedStatement[] = [];
+	for (const row of rows.results) {
+		statements.push(
+			db
+				.prepare(
+					`UPDATE superboard_plugin_lifecycle
+					 SET artifact_checksum = ?, state = 'active', plan_id = ?,
+					     state_changed_at = ?, reason = 'explicit plan activation'
+					 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
+				)
+				.bind(
+					row.artifact_checksum,
+					input.plan_id,
+					input.changed_at,
+					input.instance_id,
+					input.target,
+					row.plugin_id,
+				),
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_lifecycle_events
+					 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
+					  plan_id, reason, changed_at)
+					 VALUES (?, ?, ?, ?, ?, 'active', ?, 'explicit plan activation', ?)`,
+				)
+				.bind(
+					input.instance_id,
+					input.target,
+					row.plugin_id,
+					row.artifact_checksum,
+					row.state,
+					input.plan_id,
+					input.changed_at,
+				),
+			db
+				.prepare(
+					`UPDATE superboard_plugin_installation_items
+					 SET state = 'active' WHERE plan_id = ? AND plugin_id = ?`,
+				)
+				.bind(input.plan_id, row.plugin_id),
+			db
+				.prepare(
 					`INSERT INTO superboard_active_plugin_manifests
 					 (plugin_id, artifact_checksum, activated_at)
 					 VALUES (?, ?, ?)
@@ -124,37 +434,7 @@ export async function synchronizeSuperBoardPluginCatalog(
 					   artifact_checksum = excluded.artifact_checksum,
 					   activated_at = excluded.activated_at`,
 				)
-				.bind(manifest.plugin_id, manifest.artifact_checksum, input.checked_at),
-			db
-				.prepare(
-					`INSERT INTO _plugin_state
-					 (plugin_id, version, status, installed_at, activated_at, deactivated_at,
-					  data, source, marketplace_version, display_name, description,
-					  registry_publisher_did, registry_slug, mcp_tools_enabled, mcp_tools_consent)
-					 VALUES (?, ?, 'active', ?, ?, NULL, ?, 'config', NULL, ?, ?, NULL, NULL, 0, NULL)
-					 ON CONFLICT(plugin_id) DO UPDATE SET
-					   version = excluded.version,
-					   status = 'active',
-					   activated_at = excluded.activated_at,
-					   deactivated_at = NULL,
-					   data = excluded.data,
-					   source = 'config',
-					   display_name = excluded.display_name,
-					   description = excluded.description`,
-				)
-				.bind(
-					manifest.plugin_id,
-					manifest.plugin_version,
-					input.checked_at,
-					input.checked_at,
-					canonicalizeReleasePayload({
-						artifact_checksum: manifest.artifact_checksum,
-						plugin_kind: manifest.plugin_kind,
-						execution: manifest.execution,
-					}),
-					displayName,
-					description,
-				),
+				.bind(row.plugin_id, row.artifact_checksum, input.changed_at),
 			db
 				.prepare(
 					`INSERT INTO superboard_dependency_health
@@ -166,52 +446,243 @@ export async function synchronizeSuperBoardPluginCatalog(
 				)
 				.bind(
 					input.instance_id,
-					dependencyId,
-					evidenceChecksum,
-					input.checked_at,
-					input.expires_at,
+					dependencyId(row.plugin_id),
+					row.evidence_checksum,
+					input.changed_at,
+					row.expires_at,
 				),
 		);
-		installed.push({
-			plugin_id: manifest.plugin_id,
-			plugin_version: manifest.plugin_version,
-			artifact_checksum: manifest.artifact_checksum,
-			dependency_id: dependencyId,
-			evidence_checksum: evidenceChecksum,
-			status: "active" as const,
+	}
+	statements.push(
+		db
+			.prepare(
+				`UPDATE superboard_plugin_installation_plans
+				 SET status = 'active', completed_at = ? WHERE plan_id = ?`,
+			)
+			.bind(input.changed_at, input.plan_id),
+	);
+	await db.batch(statements);
+	await writeEmDashPluginStates(
+		db,
+		rows.results.map((row) => ({ plugin_id: row.plugin_id, version: row.plugin_version })),
+		"active",
+		input.changed_at,
+	);
+	return { ...input, status: "active" as const, plugin_count: rows.results.length };
+}
+
+export async function transitionSuperBoardPluginLifecycle(
+	db: D1Database,
+	input: PluginScope & {
+		plugin_id: string;
+		to_state: SuperBoardPluginLifecycleState;
+		changed_at: string;
+		reason: string;
+	},
+) {
+	assertScope(input);
+	if (!input.plugin_id || !input.reason.trim() || !isCanonicalTimestamp(input.changed_at)) {
+		throw new TypeError("Plugin lifecycle transition requires plugin, reason and timestamp");
+	}
+	const current = await db
+		.prepare(
+			`SELECT lifecycle.artifact_checksum, lifecycle.state, lifecycle.plan_id,
+			        json_extract(artifact.manifest_json, '$.plugin_version') AS plugin_version
+			 FROM superboard_plugin_lifecycle lifecycle
+			 JOIN superboard_plugin_manifest_artifacts artifact
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ? AND lifecycle.plugin_id = ?`,
+		)
+		.bind(input.instance_id, input.target, input.plugin_id)
+		.first<{
+			artifact_checksum: string;
+			state: SuperBoardPluginLifecycleState;
+			plan_id: string | null;
+			plugin_version: string;
+		}>();
+	if (!current) throw new Error("PLUGIN_LIFECYCLE_NOT_FOUND");
+	if (!LIFECYCLE_TRANSITIONS[current.state].includes(input.to_state)) {
+		throw new Error(`PLUGIN_LIFECYCLE_TRANSITION_INVALID:${current.state}:${input.to_state}`);
+	}
+	if (input.to_state === "active") {
+		const health = await db
+			.prepare(
+				`SELECT status, expires_at FROM superboard_plugin_runtime_health
+				 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
+			)
+			.bind(input.instance_id, input.target, input.plugin_id)
+			.first<{ status: "ready" | "unavailable"; expires_at: string }>();
+		if (
+			!health ||
+			health.status !== "ready" ||
+			Date.parse(health.expires_at) <= Date.parse(input.changed_at)
+		) {
+			throw new Error(`PLUGIN_ACTIVATION_HEALTH_NOT_READY:${input.plugin_id}`);
+		}
+	}
+
+	const statements: D1PreparedStatement[] = [
+		db
+			.prepare(
+				`UPDATE superboard_plugin_lifecycle
+				 SET state = ?, state_changed_at = ?, reason = ?
+				 WHERE instance_id = ? AND target = ? AND plugin_id = ? AND state = ?`,
+			)
+			.bind(
+				input.to_state,
+				input.changed_at,
+				input.reason,
+				input.instance_id,
+				input.target,
+				input.plugin_id,
+				current.state,
+			),
+		db
+			.prepare(
+				`INSERT INTO superboard_plugin_lifecycle_events
+				 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
+				  plan_id, reason, changed_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.bind(
+				input.instance_id,
+				input.target,
+				input.plugin_id,
+				current.artifact_checksum,
+				current.state,
+				input.to_state,
+				current.plan_id,
+				input.reason,
+				input.changed_at,
+			),
+	];
+	if (input.to_state !== "active") {
+		const unavailableEvidence = await sha256Canonical({
+			domain: "superboard.plugin_runtime_health.v1",
+			...input,
+			artifact_checksum: current.artifact_checksum,
+			status: "unavailable",
 		});
+		statements.push(
+			db
+				.prepare(
+					`DELETE FROM superboard_active_plugin_manifests
+					 WHERE plugin_id = ? AND artifact_checksum = ?`,
+				)
+				.bind(input.plugin_id, current.artifact_checksum),
+			db
+				.prepare(
+					`UPDATE superboard_plugin_runtime_health
+					 SET status = 'unavailable', evidence_checksum = ?, checked_at = ?
+					 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
+				)
+				.bind(
+					unavailableEvidence,
+					input.changed_at,
+					input.instance_id,
+					input.target,
+					input.plugin_id,
+				),
+			db
+				.prepare(
+					`UPDATE superboard_dependency_health
+					 SET status = 'unavailable', evidence_checksum = ?, checked_at = ?
+					 WHERE instance_id = ? AND dependency_id = ?`,
+				)
+				.bind(
+					unavailableEvidence,
+					input.changed_at,
+					input.instance_id,
+					dependencyId(input.plugin_id),
+				),
+		);
 	}
 	await db.batch(statements);
-	return {
-		instance_id: input.instance_id,
+	await writeEmDashPluginStates(
+		db,
+		[{ plugin_id: input.plugin_id, version: current.plugin_version }],
+		input.to_state === "active" ? "active" : "inactive",
+		input.changed_at,
+	);
+	return { ...input, from_state: current.state, state: input.to_state };
+}
+
+export async function synchronizeSuperBoardPluginCatalog(
+	db: D1Database,
+	input: {
+		instance_id: string;
+		target?: SuperBoardPluginTarget;
+		plan_id?: string;
+		checked_at: string;
+		expires_at: string;
+	},
+) {
+	const scope = { instance_id: input.instance_id, target: input.target ?? ("local" as const) };
+	const plan = await installSuperBoardPluginCatalog(db, {
+		...scope,
+		plan_id: input.plan_id ?? `plugin-plan-${crypto.randomUUID()}`,
 		checked_at: input.checked_at,
 		expires_at: input.expires_at,
-		installed,
-		templates: catalog.templates,
+	});
+	await activateSuperBoardPluginInstallationPlan(db, {
+		...scope,
+		plan_id: plan.plan_id,
+		changed_at: input.checked_at,
+	});
+	return {
+		instance_id: input.instance_id,
+		target: scope.target,
+		plan_id: plan.plan_id,
+		checked_at: input.checked_at,
+		expires_at: input.expires_at,
+		installed: plan.plugins.map((plugin) => ({
+			plugin_id: plugin.plugin_id,
+			plugin_version: plugin.derived.plugin_lock.version,
+			artifact_checksum: plugin.derived.plugin_lock.artifact_checksum,
+			dependency_id: dependencyId(plugin.plugin_id),
+			evidence_checksum: plugin.health_evidence_checksum,
+			status: "active" as const,
+		})),
+		templates: superBoardRuntimePluginCatalog().templates,
 	};
 }
 
-export async function loadActiveSuperBoardPluginLock(db: D1Database) {
+export async function loadActiveSuperBoardPluginLock(db: D1Database, scope: PluginScope) {
+	assertScope(scope);
 	const rows = await db
 		.prepare(
-			`SELECT active.plugin_id, active.artifact_checksum, artifact.manifest_json
-			 FROM superboard_active_plugin_manifests active
+			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, artifact.manifest_json,
+			        health.status AS health_status
+			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
-			   ON artifact.artifact_checksum = active.artifact_checksum
-			 WHERE active.plugin_id NOT LIKE '%*%'
-			 ORDER BY active.plugin_id`,
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
+			 JOIN superboard_plugin_runtime_health health
+			   ON health.instance_id = lifecycle.instance_id
+			  AND health.target = lifecycle.target
+			  AND health.plugin_id = lifecycle.plugin_id
+			  AND health.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ?
+			   AND lifecycle.state = 'active'
+			 ORDER BY lifecycle.plugin_id`,
 		)
-		.all<{ plugin_id: string; artifact_checksum: string; manifest_json: string }>();
+		.bind(scope.instance_id, scope.target)
+		.all<{
+			plugin_id: string;
+			artifact_checksum: string;
+			manifest_json: string;
+			health_status: "ready" | "unavailable";
+		}>();
 	if (rows.results.length === 0) throw new Error("PLUGIN_CATALOG_ACTIVE_SET_EMPTY");
 	const catalog = new Map(
 		superBoardRuntimePluginCatalog().plugins.map(({ manifest }) => [manifest.plugin_id, manifest]),
 	);
 	return Promise.all(
 		rows.results.map(async (row) => {
-			const manifest = catalog.get(row.plugin_id);
-			if (!manifest) {
-				throw new Error(`PLUGIN_CATALOG_NOT_SYNCHRONIZED:${row.plugin_id}`);
+			if (row.health_status !== "ready") {
+				throw new Error(`PLUGIN_CATALOG_HEALTH_NOT_READY:${row.plugin_id}`);
 			}
+			const manifest = catalog.get(row.plugin_id);
+			if (!manifest) throw new Error(`PLUGIN_CATALOG_NOT_SYNCHRONIZED:${row.plugin_id}`);
 			let stored: unknown;
 			try {
 				stored = JSON.parse(row.manifest_json);
@@ -248,6 +719,261 @@ export async function loadActiveSuperBoardPluginLock(db: D1Database) {
 	);
 }
 
+async function derivePluginContract(
+	plugin: SuperBoardRuntimePlugin,
+	input: PlanInput,
+): Promise<PlannedPlugin> {
+	const { manifest, worker_descriptor: workerDescriptor } = plugin;
+	const verification =
+		manifest.plugin_id === userPluginManifest.plugin_id
+			? await validateUserPluginManifest(manifest)
+			: await verifySuperBoardPluginManifest(manifest);
+	if (!verification.valid) {
+		throw new Error(`${manifest.plugin_id} manifest is invalid: ${verification.errors.join(",")}`);
+	}
+	for (const store of manifest.stores) {
+		if (store.authority !== manifest.plugin_id || store.migrations.length === 0) {
+			throw new Error(
+				`PLUGIN_STORE_MIGRATION_CONTRACT_INVALID:${manifest.plugin_id}:${store.store_id}`,
+			);
+		}
+	}
+	assertNamespacedContributions(manifest);
+	if (workerDescriptor) {
+		const { checksum, ...descriptorPayload } = workerDescriptor;
+		if ((await sha256Canonical(descriptorPayload)) !== checksum) {
+			throw new Error(`PLUGIN_WORKER_DESCRIPTOR_CHECKSUM_INVALID:${manifest.plugin_id}`);
+		}
+		if (
+			workerDescriptor.authoritative_writes ||
+			workerDescriptor.store_ids.toSorted().join("\n") !==
+				manifest.stores
+					.map(({ store_id: storeId }) => storeId)
+					.toSorted()
+					.join("\n")
+		) {
+			throw new Error(`PLUGIN_WORKER_DESCRIPTOR_SCOPE_INVALID:${manifest.plugin_id}`);
+		}
+	}
+	const stores = await Promise.all(
+		manifest.stores.map(async (store) => ({
+			store_id: store.store_id,
+			schema_version: store.schema_version,
+			migrations_checksum: await sha256Canonical(store.migrations),
+		})),
+	);
+	const workerStatus =
+		manifest.plugin_kind === "full" || workerDescriptor?.deployment_status === "ready"
+			? ("ready" as const)
+			: ("unavailable" as const);
+	const derived: DerivedPluginContract = {
+		stores,
+		capabilities: manifest.capabilities.toSorted(),
+		capability_approval_checksum: await sha256Canonical({
+			plugin_id: manifest.plugin_id,
+			artifact_checksum: manifest.artifact_checksum,
+			capabilities: manifest.capabilities.toSorted(),
+			resources: manifest.resources.toSorted(),
+		}),
+		settings_checksum: await sha256Canonical(manifest.settings),
+		contributions_checksum: await sha256Canonical({
+			schemas: manifest.schemas,
+			renderers: manifest.renderers,
+			commands: manifest.commands,
+			data_sources: manifest.data_sources,
+		}),
+		migrations_checksum: await sha256Canonical(stores),
+		worker_descriptor_checksum: workerDescriptor?.checksum ?? null,
+		worker_status: workerStatus,
+		plugin_lock: {
+			plugin_id: manifest.plugin_id,
+			version: manifest.plugin_version,
+			artifact_checksum: manifest.artifact_checksum,
+			native: manifest.execution.backend === "native",
+		},
+	};
+	return {
+		manifest,
+		worker_descriptor: workerDescriptor,
+		derived,
+		derived_contract_checksum: await sha256Canonical(derived),
+		health_evidence_checksum: await sha256Canonical({
+			domain: "superboard.plugin_runtime_health.v1",
+			instance_id: input.instance_id,
+			target: input.target,
+			plugin_id: manifest.plugin_id,
+			plugin_version: manifest.plugin_version,
+			artifact_checksum: manifest.artifact_checksum,
+			worker_descriptor_checksum: workerDescriptor?.checksum ?? null,
+			status: workerStatus,
+			checked_at: input.checked_at,
+			expires_at: input.expires_at,
+		}),
+	};
+}
+
+async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
+	const plan = await db
+		.prepare(
+			`SELECT plan_id, instance_id, target, status, catalog_checksum, plugin_count,
+			        created_at, completed_at
+			 FROM superboard_plugin_installation_plans WHERE plan_id = ?`,
+		)
+		.bind(planId)
+		.first<{
+			plan_id: string;
+			instance_id: string;
+			target: SuperBoardPluginTarget;
+			status: "installing" | "installed" | "active" | "failed";
+			catalog_checksum: string;
+			plugin_count: number;
+			created_at: string;
+			completed_at: string | null;
+		}>();
+	if (!plan) throw new Error("PLUGIN_INSTALLATION_PLAN_NOT_FOUND");
+	const items = await db
+		.prepare(
+			`SELECT plugin_id, state, derived_contract_json, derived_contract_checksum
+			 FROM superboard_plugin_installation_items
+			 WHERE plan_id = ? ORDER BY plugin_id`,
+		)
+		.bind(planId)
+		.all<{
+			plugin_id: string;
+			state: "staged" | "installed" | "active" | "failed";
+			derived_contract_json: string;
+			derived_contract_checksum: string;
+		}>();
+	const healthRows = await db
+		.prepare(
+			`SELECT plugin_id, evidence_checksum FROM superboard_plugin_runtime_health
+			 WHERE instance_id = ? AND target = ?`,
+		)
+		.bind(plan.instance_id, plan.target)
+		.all<{ plugin_id: string; evidence_checksum: string }>();
+	const health = new Map(healthRows.results.map((row) => [row.plugin_id, row.evidence_checksum]));
+	const plugins = await Promise.all(
+		items.results.map(async (item) => {
+			let derived: DerivedPluginContract;
+			try {
+				derived = JSON.parse(item.derived_contract_json) as DerivedPluginContract;
+			} catch {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
+			}
+			if ((await sha256Canonical(derived)) !== item.derived_contract_checksum) {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
+			}
+			return {
+				plugin_id: item.plugin_id,
+				state: item.state,
+				derived,
+				derived_contract_checksum: item.derived_contract_checksum,
+				health_evidence_checksum: health.get(item.plugin_id),
+			};
+		}),
+	);
+	return {
+		...plan,
+		plugins,
+	};
+}
+
+function lifecycleInstallationEvents(
+	db: D1Database,
+	input: PlanInput & {
+		plugin_id: string;
+		artifact_checksum: string;
+		current_state: SuperBoardPluginLifecycleState | undefined;
+		to_state: "staged" | "installed";
+	},
+): D1PreparedStatement[] {
+	const path: SuperBoardPluginLifecycleState[] = [];
+	if (!input.current_state) path.push("available", "staged");
+	else if (input.current_state === "available") path.push("staged");
+	else if (input.current_state === "disabled") path.push("staged");
+	else if (input.current_state === "purged") path.push("available", "staged");
+	if (input.to_state === "installed" && input.current_state !== "installed") path.push("installed");
+	const statements: D1PreparedStatement[] = [];
+	let fromState: SuperBoardPluginLifecycleState | null = input.current_state ?? null;
+	for (const toState of path) {
+		statements.push(
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_lifecycle_events
+					 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
+					  plan_id, reason, changed_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, 'installation plan', ?)`,
+				)
+				.bind(
+					input.instance_id,
+					input.target,
+					input.plugin_id,
+					input.artifact_checksum,
+					fromState,
+					toState,
+					input.plan_id,
+					input.checked_at,
+				),
+		);
+		fromState = toState;
+	}
+	return statements;
+}
+
+async function writeEmDashPluginStates(
+	db: D1Database,
+	plugins: readonly { plugin_id: string; version: string }[],
+	status: "active" | "inactive",
+	changedAt: string,
+): Promise<void> {
+	if (plugins.length === 0) return;
+	try {
+		await db.batch(
+			plugins.map(({ plugin_id: pluginId, version }) =>
+				db
+					.prepare(
+						`INSERT INTO _plugin_state
+						 (plugin_id, version, status, installed_at, activated_at, deactivated_at, source)
+						 VALUES (?, ?, ?, ?, ?, ?, 'config')
+						 ON CONFLICT(plugin_id) DO UPDATE SET
+						   version = excluded.version,
+						   status = excluded.status,
+						   activated_at = excluded.activated_at,
+						   deactivated_at = excluded.deactivated_at,
+						   source = 'config'`,
+					)
+					.bind(
+						pluginId,
+						version,
+						status,
+						changedAt,
+						status === "active" ? changedAt : null,
+						status === "inactive" ? changedAt : null,
+					),
+			),
+		);
+	} catch (error) {
+		if (error instanceof Error && MISSING_PLUGIN_STATE_TABLE_PATTERN.test(error.message)) return;
+		throw error;
+	}
+}
+
+function assertNamespacedContributions(manifest: SuperBoardPluginManifest): void {
+	const ids = [
+		...manifest.stores.map(({ store_id: id }) => id),
+		...manifest.schemas.map(({ schema_id: id }) => id),
+		...manifest.renderers.map(({ renderer_id: id }) => id),
+		...manifest.commands.map(({ command_id: id }) => id),
+		...manifest.data_sources.map(({ data_source_id: id }) => id),
+	];
+	if (ids.some((id) => !id.startsWith(`${manifest.plugin_id}.`))) {
+		throw new Error(`PLUGIN_CONTRIBUTION_NAMESPACE_INVALID:${manifest.plugin_id}`);
+	}
+	if (new Set(ids).size !== ids.length) {
+		throw new Error(`PLUGIN_CONTRIBUTION_COLLISION:${manifest.plugin_id}`);
+	}
+}
+
 async function verifyCompatibleStoredManifest(
 	stored: unknown,
 	pluginId: string,
@@ -266,12 +992,26 @@ async function verifyCompatibleStoredManifest(
 	return { valid: errors.length === 0, errors: [...new Set(errors)] };
 }
 
-function displayPluginName(pluginId: string): string {
-	return pluginId
-		.replace(PLUGIN_ID_PREFIX_PATTERN, "")
-		.split("-")
-		.map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
-		.join(" ");
+function dependencyId(pluginId: string): string {
+	return `dependency.${pluginId.replaceAll("-", "_")}`;
+}
+
+function assertPlanInput(input: PlanInput): void {
+	assertScope(input);
+	if (
+		!input.plan_id ||
+		!isCanonicalTimestamp(input.checked_at) ||
+		!isCanonicalTimestamp(input.expires_at) ||
+		Date.parse(input.expires_at) <= Date.parse(input.checked_at)
+	) {
+		throw new TypeError("Plugin installation plan requires a bounded validity window");
+	}
+}
+
+function assertScope(input: PluginScope): void {
+	if (!input.instance_id || !TARGETS.has(input.target)) {
+		throw new TypeError("Plugin lifecycle requires a valid Instance and target");
+	}
 }
 
 function isCanonicalTimestamp(value: string): boolean {

--- a/apps/site/src/lib/superboard-plugin-catalog.ts
+++ b/apps/site/src/lib/superboard-plugin-catalog.ts
@@ -343,7 +343,7 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 			.bind(
 				failed ? "failed" : "installed",
 				input.checked_at,
-				failed ? "completed" : "not_required",
+				"not_required",
 				failed
 					? canonicalizeReleasePayload({
 							code: "PLUGIN_INSTALLATION_PLAN_NOT_READY",
@@ -481,17 +481,27 @@ export async function finalizeSuperBoardPluginLifecycleForRelease(
 	}
 	const reconciliation = await db
 		.prepare(
-			`SELECT status FROM superboard_plugin_release_reconciliations
-			 WHERE instance_id = ? AND target = ? AND release_id = ?`,
+			`SELECT reconciliation.status, reconciliation.plugin_lock_json,
+			        active.active_release_id
+			 FROM superboard_plugin_release_reconciliations reconciliation
+			 LEFT JOIN superboard_front_active_releases active
+			   ON active.instance_id = reconciliation.instance_id
+			  AND active.active_release_id = reconciliation.release_id
+			 WHERE reconciliation.instance_id = ? AND reconciliation.target = ?
+			   AND reconciliation.release_id = ?`,
 		)
 		.bind(input.instance_id, input.target, input.release_id)
-		.first<{ status: "prepared" | "applied" }>();
-	if (reconciliation?.status !== "applied") {
+		.first<{
+			status: "prepared" | "applied";
+			plugin_lock_json: string;
+			active_release_id: string | null;
+		}>();
+	if (reconciliation?.status !== "applied" || !reconciliation.active_release_id) {
 		throw new Error("PLUGIN_RELEASE_RECONCILIATION_NOT_APPLIED");
 	}
 	const rows = await db
 		.prepare(
-			`SELECT lifecycle.plugin_id, lifecycle.state,
+			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, lifecycle.state,
 			        json_extract(artifact.manifest_json, '$.plugin_version') AS plugin_version
 			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
@@ -502,9 +512,37 @@ export async function finalizeSuperBoardPluginLifecycleForRelease(
 			 ORDER BY lifecycle.plugin_id`,
 		)
 		.bind(input.instance_id, input.target, input.release_id)
-		.all<{ plugin_id: string; state: "active" | "disabled"; plugin_version: string }>();
+		.all<{
+			plugin_id: string;
+			artifact_checksum: string;
+			state: "active" | "disabled";
+			plugin_version: string;
+		}>();
 	const activated = rows.results.filter(({ state }) => state === "active");
 	const disabled = rows.results.filter(({ state }) => state === "disabled");
+	let preparedLock: PluginLockEntry[];
+	try {
+		const parsed: unknown = JSON.parse(reconciliation.plugin_lock_json);
+		if (!Array.isArray(parsed)) throw new TypeError("Plugin Lock is not an array");
+		preparedLock = parsed as PluginLockEntry[];
+	} catch {
+		throw new Error("PLUGIN_RELEASE_LOCK_INVALID");
+	}
+	const desired = preparedLock.filter(({ plugin_id: pluginId }) => pluginId !== "supbrd-core");
+	const activeById = new Map(activated.map((row) => [row.plugin_id, row]));
+	if (
+		activeById.size !== desired.length ||
+		desired.some((lock) => {
+			const row = activeById.get(lock.plugin_id);
+			return (
+				!row ||
+				row.plugin_version !== lock.version ||
+				row.artifact_checksum !== lock.artifact_checksum
+			);
+		})
+	) {
+		throw new Error("PLUGIN_RELEASE_RECONCILIATION_INCOMPLETE");
+	}
 	await writeEmDashPluginStates(
 		db,
 		activated.map(({ plugin_id: pluginId, plugin_version: version }) => ({

--- a/apps/site/src/lib/superboard-plugin-catalog.ts
+++ b/apps/site/src/lib/superboard-plugin-catalog.ts
@@ -40,6 +40,7 @@ interface PluginScope {
 
 interface PlanInput extends PluginScope {
 	plan_id: string;
+	approved_by: string;
 	checked_at: string;
 	expires_at: string;
 	plugin_ids?: readonly string[];
@@ -54,13 +55,26 @@ interface DerivedPluginContract {
 	migrations_checksum: string;
 	worker_descriptor_checksum: string | null;
 	worker_status: "ready" | "unavailable";
-	plugin_lock: {
-		plugin_id: string;
-		version: string;
-		artifact_checksum: string;
-		native: boolean;
-	};
+	step_receipts: Record<PluginInstallationStep, string>;
+	plugin_lock: PluginLockEntry;
 }
+
+interface PluginLockEntry {
+	plugin_id: string;
+	version: string;
+	artifact_checksum: string;
+	native: boolean;
+}
+
+type PluginInstallationStep =
+	| "artifact_verified"
+	| "publisher_verified"
+	| "capabilities_approved"
+	| "stores_provisioned"
+	| "migration_graph_verified"
+	| "worker_deployed_inactive"
+	| "health_verified"
+	| "release_contract_ready";
 
 interface PlannedPlugin {
 	manifest: SuperBoardPluginManifest;
@@ -82,9 +96,9 @@ const LIFECYCLE_TRANSITIONS: Record<
 > = {
 	available: ["staged"],
 	staged: ["installed", "quarantined"],
-	installed: ["active", "quarantined"],
+	installed: ["quarantined"],
 	active: ["draining", "quarantined"],
-	draining: ["disabled", "quarantined"],
+	draining: ["quarantined"],
 	disabled: ["staged", "quarantined"],
 	quarantined: ["staged", "purged"],
 	purged: ["available"],
@@ -151,7 +165,34 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 		if (existing.instance_id !== input.instance_id || existing.target !== input.target) {
 			throw new Error("PLUGIN_INSTALLATION_PLAN_SCOPE_MISMATCH");
 		}
-		return loadInstallationPlanReceipt(db, input.plan_id);
+		const receipt = await loadInstallationPlanReceipt(db, input.plan_id);
+		if (receipt.status === "failed") throw new Error("PLUGIN_INSTALLATION_PLAN_FAILED");
+		if (receipt.status === "installed") {
+			const active = await db
+				.prepare(
+					`SELECT plugin_id FROM superboard_plugin_lifecycle
+					 WHERE instance_id = ? AND target = ? AND state = 'active'`,
+				)
+				.bind(input.instance_id, input.target)
+				.all<{ plugin_id: string }>();
+			const activeIds = new Set(active.results.map(({ plugin_id: pluginId }) => pluginId));
+			await writeEmDashPluginStates(
+				db,
+				receipt.plugins.flatMap(({ derived }) =>
+					activeIds.has(derived.plugin_lock.plugin_id)
+						? []
+						: [
+								{
+									plugin_id: derived.plugin_lock.plugin_id,
+									version: derived.plugin_lock.version,
+								},
+							],
+				),
+				"inactive",
+				input.checked_at,
+			);
+		}
+		return receipt;
 	}
 
 	const catalog = superBoardRuntimePluginCatalog();
@@ -162,6 +203,7 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	if (selected.length === 0 || (selectedIds && selected.length !== selectedIds.size)) {
 		throw new Error("PLUGIN_INSTALLATION_PLAN_UNKNOWN_PLUGIN");
 	}
+	await db.prepare("SELECT 1 FROM superboard_plugin_store_records LIMIT 1").first();
 	const planned = await Promise.all(selected.map((plugin) => derivePluginContract(plugin, input)));
 	const catalogChecksum = await sha256Canonical(planned.map(({ derived }) => derived.plugin_lock));
 	const unavailable = planned.filter(({ derived }) => derived.worker_status !== "ready");
@@ -231,6 +273,7 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 					plugin.derived_contract_checksum,
 					derived.worker_status,
 				),
+			installationStepsStatement(db, input, plugin),
 			db
 				.prepare(
 					`INSERT INTO superboard_plugin_runtime_health
@@ -295,12 +338,13 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 		db
 			.prepare(
 				`UPDATE superboard_plugin_installation_plans
-				 SET status = ?, completed_at = ?, failure_json = ?
+				 SET status = ?, completed_at = ?, compensation_status = ?, failure_json = ?
 				 WHERE plan_id = ? AND status = 'installing'`,
 			)
 			.bind(
 				failed ? "failed" : "installed",
 				input.checked_at,
+				failed ? "completed" : "not_required",
 				failed
 					? canonicalizeReleasePayload({
 							code: "PLUGIN_INSTALLATION_PLAN_NOT_READY",
@@ -330,145 +374,239 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	return loadInstallationPlanReceipt(db, input.plan_id);
 }
 
-export async function activateSuperBoardPluginInstallationPlan(
+export async function reconcileSuperBoardPluginLifecycleForRelease(
 	db: D1Database,
-	input: PluginScope & { plan_id: string; changed_at: string },
+	input: PluginScope & {
+		release_id: string;
+		plugin_lock: readonly PluginLockEntry[];
+		activated_at: string;
+	},
 ) {
 	assertScope(input);
-	if (!input.plan_id || !isCanonicalTimestamp(input.changed_at)) {
-		throw new TypeError("Plugin activation requires a plan and canonical timestamp");
+	if (!input.release_id || !isCanonicalTimestamp(input.activated_at)) {
+		throw new TypeError("Plugin lifecycle reconciliation requires a Release and timestamp");
 	}
-	const plan = await loadInstallationPlanReceipt(db, input.plan_id);
-	if (plan.instance_id !== input.instance_id || plan.target !== input.target) {
-		throw new Error("PLUGIN_INSTALLATION_PLAN_SCOPE_MISMATCH");
+	const activeRelease = await db
+		.prepare(
+			`SELECT candidate.release_json
+			 FROM superboard_front_active_releases active
+			 JOIN superboard_front_release_candidates candidate
+			   ON candidate.instance_id = active.instance_id
+			  AND candidate.release_id = active.active_release_id
+			 WHERE active.instance_id = ? AND active.active_release_id = ?
+			   AND candidate.status = 'activated'`,
+		)
+		.bind(input.instance_id, input.release_id)
+		.first<{ release_json: string }>();
+	if (!activeRelease) throw new Error("PLUGIN_RELEASE_NOT_ACTIVE");
+	let activePluginLock: unknown;
+	try {
+		const release: unknown = JSON.parse(activeRelease.release_json);
+		activePluginLock =
+			typeof release === "object" &&
+			release !== null &&
+			"payload" in release &&
+			typeof release.payload === "object" &&
+			release.payload !== null &&
+			"plugin_lock" in release.payload
+				? release.payload.plugin_lock
+				: null;
+	} catch {
+		throw new Error("PLUGIN_RELEASE_LOCK_INVALID");
 	}
-	if (plan.status === "active") {
-		return { ...input, status: "active" as const, plugin_count: plan.plugin_count };
+	if (
+		canonicalizeReleasePayload(activePluginLock) !== canonicalizeReleasePayload(input.plugin_lock)
+	) {
+		throw new Error("PLUGIN_RELEASE_LOCK_MISMATCH");
 	}
-	if (plan.status !== "installed") throw new Error("PLUGIN_INSTALLATION_PLAN_NOT_INSTALLED");
+	const desiredLocks = input.plugin_lock.filter(
+		({ plugin_id: pluginId }) => pluginId !== "supbrd-core",
+	);
+	const releasableLocks = await loadReleasableSuperBoardPluginLock(db, input);
+	const releasable = new Map(releasableLocks.map((lock) => [lock.plugin_id, lock]));
+	for (const lock of desiredLocks) {
+		const current = releasable.get(lock.plugin_id);
+		if (
+			!current ||
+			current.version !== lock.version ||
+			current.artifact_checksum !== lock.artifact_checksum ||
+			current.native !== lock.native
+		) {
+			throw new Error(`PLUGIN_RELEASE_LOCK_NOT_RELEASABLE:${lock.plugin_id}`);
+		}
+	}
+	const desired = new Set(desiredLocks.map(({ plugin_id: pluginId }) => pluginId));
 	const rows = await db
 		.prepare(
-			`SELECT item.plugin_id, item.artifact_checksum, item.health_status,
-			        health.evidence_checksum, health.expires_at, lifecycle.state,
-			        json_extract(item.derived_contract_json, '$.plugin_lock.version') AS plugin_version
-			 FROM superboard_plugin_installation_items item
+			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, lifecycle.state,
+			        lifecycle.plan_id, health.evidence_checksum, health.expires_at,
+			        json_extract(artifact.manifest_json, '$.plugin_version') AS plugin_version
+			 FROM superboard_plugin_lifecycle lifecycle
+			 JOIN superboard_plugin_manifest_artifacts artifact
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
 			 JOIN superboard_plugin_runtime_health health
-			   ON health.instance_id = ? AND health.target = ?
-			  AND health.plugin_id = item.plugin_id
-			 JOIN superboard_plugin_lifecycle lifecycle
-			   ON lifecycle.instance_id = ? AND lifecycle.target = ?
-			  AND lifecycle.plugin_id = item.plugin_id
-			 WHERE item.plan_id = ?
-			 ORDER BY item.plugin_id`,
+			   ON health.instance_id = lifecycle.instance_id
+			  AND health.target = lifecycle.target
+			  AND health.plugin_id = lifecycle.plugin_id
+			  AND health.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ?
+			 ORDER BY lifecycle.plugin_id`,
 		)
-		.bind(input.instance_id, input.target, input.instance_id, input.target, input.plan_id)
+		.bind(input.instance_id, input.target)
 		.all<{
 			plugin_id: string;
 			artifact_checksum: string;
-			health_status: "ready" | "unavailable";
+			state: SuperBoardPluginLifecycleState;
+			plan_id: string | null;
 			evidence_checksum: string;
 			expires_at: string;
-			state: SuperBoardPluginLifecycleState;
 			plugin_version: string;
 		}>();
-	if (rows.results.length !== plan.plugin_count)
-		throw new Error("PLUGIN_INSTALLATION_PLAN_INCOMPLETE");
 	for (const row of rows.results) {
-		if (
-			row.health_status !== "ready" ||
-			Date.parse(row.expires_at) <= Date.parse(input.changed_at)
-		) {
-			throw new Error(`PLUGIN_ACTIVATION_HEALTH_NOT_READY:${row.plugin_id}`);
-		}
-		if (row.state !== "installed" && row.state !== "active") {
-			throw new Error(`PLUGIN_ACTIVATION_STATE_INVALID:${row.plugin_id}:${row.state}`);
+		if (row.state === "active" && !desired.has(row.plugin_id)) {
+			throw new Error(`PLUGIN_RELEASE_DRAIN_REQUIRED:${row.plugin_id}`);
 		}
 	}
 
 	const statements: D1PreparedStatement[] = [];
+	const activated: Array<{ plugin_id: string; version: string }> = [];
+	const disabled: Array<{ plugin_id: string; version: string }> = [];
 	for (const row of rows.results) {
+		if (desired.has(row.plugin_id)) {
+			if (row.state !== "installed" && row.state !== "active") {
+				throw new Error(`PLUGIN_RELEASE_STATE_INVALID:${row.plugin_id}:${row.state}`);
+			}
+			statements.push(
+				db
+					.prepare(
+						`UPDATE superboard_plugin_lifecycle
+						 SET state = 'active', activated_release_id = ?, state_changed_at = ?,
+						     reason = 'Front Release activation'
+						 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
+					)
+					.bind(
+						input.release_id,
+						input.activated_at,
+						input.instance_id,
+						input.target,
+						row.plugin_id,
+					),
+				db
+					.prepare(
+						`UPDATE superboard_plugin_installation_items
+						 SET state = 'active' WHERE plan_id = ? AND plugin_id = ?`,
+					)
+					.bind(row.plan_id, row.plugin_id),
+				db
+					.prepare(
+						`INSERT INTO superboard_active_plugin_manifests
+						 (plugin_id, artifact_checksum, activated_at)
+						 VALUES (?, ?, ?)
+						 ON CONFLICT(plugin_id) DO UPDATE SET
+						   artifact_checksum = excluded.artifact_checksum,
+						   activated_at = excluded.activated_at`,
+					)
+					.bind(row.plugin_id, row.artifact_checksum, input.activated_at),
+				db
+					.prepare(
+						`INSERT INTO superboard_dependency_health
+						 (instance_id, dependency_id, status, evidence_checksum, checked_at, expires_at)
+						 VALUES (?, ?, 'ready', ?, ?, ?)
+						 ON CONFLICT(instance_id, dependency_id) DO UPDATE SET
+						   status = 'ready', evidence_checksum = excluded.evidence_checksum,
+						   checked_at = excluded.checked_at, expires_at = excluded.expires_at`,
+					)
+					.bind(
+						input.instance_id,
+						dependencyId(row.plugin_id),
+						row.evidence_checksum,
+						input.activated_at,
+						row.expires_at,
+					),
+			);
+			if (row.state === "installed") {
+				statements.push(
+					lifecycleEventStatement(db, {
+						...input,
+						plugin_id: row.plugin_id,
+						artifact_checksum: row.artifact_checksum,
+						from_state: "installed",
+						to_state: "active",
+						plan_id: row.plan_id,
+						reason: "Front Release activation",
+						changed_at: input.activated_at,
+					}),
+				);
+			}
+			activated.push({ plugin_id: row.plugin_id, version: row.plugin_version });
+			continue;
+		}
+		if (row.state === "draining") {
+			statements.push(
+				db
+					.prepare(
+						`UPDATE superboard_plugin_lifecycle
+						 SET state = 'disabled', activated_release_id = ?, state_changed_at = ?,
+						     reason = 'Front Release removed plugin'
+						 WHERE instance_id = ? AND target = ? AND plugin_id = ? AND state = 'draining'`,
+					)
+					.bind(
+						input.release_id,
+						input.activated_at,
+						input.instance_id,
+						input.target,
+						row.plugin_id,
+					),
+				lifecycleEventStatement(db, {
+					...input,
+					plugin_id: row.plugin_id,
+					artifact_checksum: row.artifact_checksum,
+					from_state: "draining",
+					to_state: "disabled",
+					plan_id: row.plan_id,
+					reason: "Front Release removed plugin",
+					changed_at: input.activated_at,
+				}),
+				db
+					.prepare(
+						`DELETE FROM superboard_active_plugin_manifests
+						 WHERE plugin_id = ? AND artifact_checksum = ?`,
+					)
+					.bind(row.plugin_id, row.artifact_checksum),
+			);
+			disabled.push({ plugin_id: row.plugin_id, version: row.plugin_version });
+		}
+	}
+	for (const installationPlanId of new Set(
+		rows.results.flatMap(({ plan_id: resolvedPlanId }) => (resolvedPlanId ? [resolvedPlanId] : [])),
+	)) {
 		statements.push(
 			db
 				.prepare(
-					`UPDATE superboard_plugin_lifecycle
-					 SET artifact_checksum = ?, state = 'active', plan_id = ?,
-					     state_changed_at = ?, reason = 'explicit plan activation'
-					 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
+					`UPDATE superboard_plugin_installation_plans
+					 SET status = 'active', completed_at = ?
+					 WHERE plan_id = ? AND status = 'installed'
+					   AND NOT EXISTS (
+					     SELECT 1 FROM superboard_plugin_installation_items item
+					     WHERE item.plan_id = ? AND item.state <> 'active'
+					   )`,
 				)
-				.bind(
-					row.artifact_checksum,
-					input.plan_id,
-					input.changed_at,
-					input.instance_id,
-					input.target,
-					row.plugin_id,
-				),
-			db
-				.prepare(
-					`INSERT INTO superboard_plugin_lifecycle_events
-					 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
-					  plan_id, reason, changed_at)
-					 VALUES (?, ?, ?, ?, ?, 'active', ?, 'explicit plan activation', ?)`,
-				)
-				.bind(
-					input.instance_id,
-					input.target,
-					row.plugin_id,
-					row.artifact_checksum,
-					row.state,
-					input.plan_id,
-					input.changed_at,
-				),
-			db
-				.prepare(
-					`UPDATE superboard_plugin_installation_items
-					 SET state = 'active' WHERE plan_id = ? AND plugin_id = ?`,
-				)
-				.bind(input.plan_id, row.plugin_id),
-			db
-				.prepare(
-					`INSERT INTO superboard_active_plugin_manifests
-					 (plugin_id, artifact_checksum, activated_at)
-					 VALUES (?, ?, ?)
-					 ON CONFLICT(plugin_id) DO UPDATE SET
-					   artifact_checksum = excluded.artifact_checksum,
-					   activated_at = excluded.activated_at`,
-				)
-				.bind(row.plugin_id, row.artifact_checksum, input.changed_at),
-			db
-				.prepare(
-					`INSERT INTO superboard_dependency_health
-					 (instance_id, dependency_id, status, evidence_checksum, checked_at, expires_at)
-					 VALUES (?, ?, 'ready', ?, ?, ?)
-					 ON CONFLICT(instance_id, dependency_id) DO UPDATE SET
-					   status = 'ready', evidence_checksum = excluded.evidence_checksum,
-					   checked_at = excluded.checked_at, expires_at = excluded.expires_at`,
-				)
-				.bind(
-					input.instance_id,
-					dependencyId(row.plugin_id),
-					row.evidence_checksum,
-					input.changed_at,
-					row.expires_at,
-				),
+				.bind(input.activated_at, installationPlanId, installationPlanId),
 		);
 	}
-	statements.push(
-		db
-			.prepare(
-				`UPDATE superboard_plugin_installation_plans
-				 SET status = 'active', completed_at = ? WHERE plan_id = ?`,
-			)
-			.bind(input.changed_at, input.plan_id),
-	);
 	await db.batch(statements);
-	await writeEmDashPluginStates(
-		db,
-		rows.results.map((row) => ({ plugin_id: row.plugin_id, version: row.plugin_version })),
-		"active",
-		input.changed_at,
-	);
-	return { ...input, status: "active" as const, plugin_count: rows.results.length };
+	await writeEmDashPluginStates(db, activated, "active", input.activated_at);
+	await writeEmDashPluginStates(db, disabled, "inactive", input.activated_at);
+	return {
+		instance_id: input.instance_id,
+		target: input.target,
+		release_id: input.release_id,
+		status: "reconciled" as const,
+		plugin_count: activated.length,
+		disabled_count: disabled.length,
+		activated_plugin_ids: activated.map(({ plugin_id: pluginId }) => pluginId),
+		disabled_plugin_ids: disabled.map(({ plugin_id: pluginId }) => pluginId),
+	};
 }
 
 export async function transitionSuperBoardPluginLifecycle(
@@ -613,6 +751,7 @@ export async function synchronizeSuperBoardPluginCatalog(
 		instance_id: string;
 		target?: SuperBoardPluginTarget;
 		plan_id?: string;
+		approved_by: string;
 		checked_at: string;
 		expires_at: string;
 	},
@@ -621,13 +760,9 @@ export async function synchronizeSuperBoardPluginCatalog(
 	const plan = await installSuperBoardPluginCatalog(db, {
 		...scope,
 		plan_id: input.plan_id ?? `plugin-plan-${crypto.randomUUID()}`,
+		approved_by: input.approved_by,
 		checked_at: input.checked_at,
 		expires_at: input.expires_at,
-	});
-	await activateSuperBoardPluginInstallationPlan(db, {
-		...scope,
-		plan_id: plan.plan_id,
-		changed_at: input.checked_at,
 	});
 	return {
 		instance_id: input.instance_id,
@@ -641,18 +776,32 @@ export async function synchronizeSuperBoardPluginCatalog(
 			artifact_checksum: plugin.derived.plugin_lock.artifact_checksum,
 			dependency_id: dependencyId(plugin.plugin_id),
 			evidence_checksum: plugin.health_evidence_checksum,
-			status: "active" as const,
+			status: "installed" as const,
 		})),
 		templates: superBoardRuntimePluginCatalog().templates,
 	};
 }
 
-export async function loadActiveSuperBoardPluginLock(db: D1Database, scope: PluginScope) {
+export function loadActiveSuperBoardPluginLock(db: D1Database, scope: PluginScope) {
+	return loadSuperBoardPluginLock(db, scope, false);
+}
+
+export function loadReleasableSuperBoardPluginLock(db: D1Database, scope: PluginScope) {
+	return loadSuperBoardPluginLock(db, scope, true);
+}
+
+async function loadSuperBoardPluginLock(
+	db: D1Database,
+	scope: PluginScope,
+	includeInstalled: boolean,
+) {
 	assertScope(scope);
-	const rows = await db
+	const result = await db
 		.prepare(
 			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, artifact.manifest_json,
-			        health.status AS health_status
+			        lifecycle.state, health.status AS health_status,
+			        item.derived_contract_json, item.derived_contract_checksum,
+			        steps.step_count, steps.completed_count
 			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
 			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
@@ -661,8 +810,16 @@ export async function loadActiveSuperBoardPluginLock(db: D1Database, scope: Plug
 			  AND health.target = lifecycle.target
 			  AND health.plugin_id = lifecycle.plugin_id
 			  AND health.artifact_checksum = lifecycle.artifact_checksum
+			 LEFT JOIN superboard_plugin_installation_items item
+			   ON item.plan_id = lifecycle.plan_id AND item.plugin_id = lifecycle.plugin_id
+			  AND item.artifact_checksum = lifecycle.artifact_checksum
+			 LEFT JOIN (
+			   SELECT plan_id, plugin_id, COUNT(*) AS step_count,
+			          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count
+			   FROM superboard_plugin_installation_steps GROUP BY plan_id, plugin_id
+			 ) steps ON steps.plan_id = item.plan_id AND steps.plugin_id = item.plugin_id
 			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ?
-			   AND lifecycle.state = 'active'
+			   AND lifecycle.state IN ('installed', 'active')
 			 ORDER BY lifecycle.plugin_id`,
 		)
 		.bind(scope.instance_id, scope.target)
@@ -670,16 +827,47 @@ export async function loadActiveSuperBoardPluginLock(db: D1Database, scope: Plug
 			plugin_id: string;
 			artifact_checksum: string;
 			manifest_json: string;
+			state: "installed" | "active";
 			health_status: "ready" | "unavailable";
+			derived_contract_json: string | null;
+			derived_contract_checksum: string | null;
+			step_count: number | null;
+			completed_count: number | null;
 		}>();
-	if (rows.results.length === 0) throw new Error("PLUGIN_CATALOG_ACTIVE_SET_EMPTY");
+	const rows = includeInstalled
+		? result.results
+		: result.results.filter(({ state }) => state === "active");
+	if (rows.length === 0) {
+		throw new Error(
+			includeInstalled ? "PLUGIN_CATALOG_RELEASABLE_SET_EMPTY" : "PLUGIN_CATALOG_ACTIVE_SET_EMPTY",
+		);
+	}
 	const catalog = new Map(
 		superBoardRuntimePluginCatalog().plugins.map(({ manifest }) => [manifest.plugin_id, manifest]),
 	);
 	return Promise.all(
-		rows.results.map(async (row) => {
+		rows.map(async (row) => {
 			if (row.health_status !== "ready") {
 				throw new Error(`PLUGIN_CATALOG_HEALTH_NOT_READY:${row.plugin_id}`);
+			}
+			if (!row.derived_contract_json || !row.derived_contract_checksum) {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_MISSING:${row.plugin_id}`);
+			}
+			if (row.step_count !== 8 || row.completed_count !== 8) {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_STEPS_INCOMPLETE:${row.plugin_id}`);
+			}
+			let derived: DerivedPluginContract;
+			try {
+				derived = JSON.parse(row.derived_contract_json) as DerivedPluginContract;
+			} catch {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${row.plugin_id}`);
+			}
+			if (
+				(await sha256Canonical(derived)) !== row.derived_contract_checksum ||
+				derived.plugin_lock.plugin_id !== row.plugin_id ||
+				derived.plugin_lock.artifact_checksum !== row.artifact_checksum
+			) {
+				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${row.plugin_id}`);
 			}
 			const manifest = catalog.get(row.plugin_id);
 			if (!manifest) throw new Error(`PLUGIN_CATALOG_NOT_SYNCHRONIZED:${row.plugin_id}`);
@@ -731,6 +919,9 @@ async function derivePluginContract(
 	if (!verification.valid) {
 		throw new Error(`${manifest.plugin_id} manifest is invalid: ${verification.errors.join(",")}`);
 	}
+	if (manifest.publisher !== "superboard") {
+		throw new Error(`PLUGIN_PUBLISHER_NOT_APPROVED:${manifest.plugin_id}`);
+	}
 	for (const store of manifest.stores) {
 		if (store.authority !== manifest.plugin_id || store.migrations.length === 0) {
 			throw new Error(
@@ -766,31 +957,77 @@ async function derivePluginContract(
 		manifest.plugin_kind === "full" || workerDescriptor?.deployment_status === "ready"
 			? ("ready" as const)
 			: ("unavailable" as const);
+	const capabilities = manifest.capabilities.toSorted();
+	const capabilityApprovalChecksum = await sha256Canonical({
+		plugin_id: manifest.plugin_id,
+		artifact_checksum: manifest.artifact_checksum,
+		capabilities,
+		resources: manifest.resources.toSorted(),
+		approved_by: input.approved_by,
+		approved_at: input.checked_at,
+	});
+	const settingsChecksum = await sha256Canonical(manifest.settings);
+	const contributionsChecksum = await sha256Canonical({
+		schemas: manifest.schemas,
+		renderers: manifest.renderers,
+		commands: manifest.commands,
+		data_sources: manifest.data_sources,
+	});
+	const migrationsChecksum = await sha256Canonical(stores);
+	const workerDescriptorChecksum = workerDescriptor?.checksum ?? null;
+	const pluginLock = {
+		plugin_id: manifest.plugin_id,
+		version: manifest.plugin_version,
+		artifact_checksum: manifest.artifact_checksum,
+		native: manifest.execution.backend === "native",
+	};
+	const stepReceipts: Record<PluginInstallationStep, string> = {
+		artifact_verified: await sha256Canonical({
+			domain: "superboard.plugin_installation.artifact_verified.v1",
+			artifact_id: manifest.artifact_id,
+			artifact_checksum: manifest.artifact_checksum,
+		}),
+		publisher_verified: await sha256Canonical({
+			domain: "superboard.plugin_installation.publisher_verified.v1",
+			publisher: manifest.publisher,
+			plugin_id: manifest.plugin_id,
+		}),
+		capabilities_approved: capabilityApprovalChecksum,
+		stores_provisioned: await sha256Canonical({
+			domain: "superboard.plugin_installation.stores_provisioned.v1",
+			stores,
+		}),
+		migration_graph_verified: migrationsChecksum,
+		worker_deployed_inactive: await sha256Canonical({
+			domain: "superboard.plugin_installation.worker_deployed_inactive.v1",
+			worker_descriptor_checksum: workerDescriptorChecksum,
+			contributions_active: false,
+		}),
+		health_verified: await sha256Canonical({
+			domain: "superboard.plugin_installation.health_verified.v1",
+			worker_descriptor_checksum: workerDescriptorChecksum,
+			status: workerStatus,
+			checked_at: input.checked_at,
+			expires_at: input.expires_at,
+		}),
+		release_contract_ready: await sha256Canonical({
+			domain: "superboard.plugin_installation.release_contract_ready.v1",
+			plugin_lock: pluginLock,
+			settings_checksum: settingsChecksum,
+			contributions_checksum: contributionsChecksum,
+		}),
+	};
 	const derived: DerivedPluginContract = {
 		stores,
-		capabilities: manifest.capabilities.toSorted(),
-		capability_approval_checksum: await sha256Canonical({
-			plugin_id: manifest.plugin_id,
-			artifact_checksum: manifest.artifact_checksum,
-			capabilities: manifest.capabilities.toSorted(),
-			resources: manifest.resources.toSorted(),
-		}),
-		settings_checksum: await sha256Canonical(manifest.settings),
-		contributions_checksum: await sha256Canonical({
-			schemas: manifest.schemas,
-			renderers: manifest.renderers,
-			commands: manifest.commands,
-			data_sources: manifest.data_sources,
-		}),
-		migrations_checksum: await sha256Canonical(stores),
-		worker_descriptor_checksum: workerDescriptor?.checksum ?? null,
+		capabilities,
+		capability_approval_checksum: capabilityApprovalChecksum,
+		settings_checksum: settingsChecksum,
+		contributions_checksum: contributionsChecksum,
+		migrations_checksum: migrationsChecksum,
+		worker_descriptor_checksum: workerDescriptorChecksum,
 		worker_status: workerStatus,
-		plugin_lock: {
-			plugin_id: manifest.plugin_id,
-			version: manifest.plugin_version,
-			artifact_checksum: manifest.artifact_checksum,
-			native: manifest.execution.backend === "native",
-		},
+		step_receipts: stepReceipts,
+		plugin_lock: pluginLock,
 	};
 	return {
 		manifest,
@@ -813,14 +1050,22 @@ async function derivePluginContract(
 }
 
 async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
-	const plan = await db
+	const result = await db
 		.prepare(
-			`SELECT plan_id, instance_id, target, status, catalog_checksum, plugin_count,
-			        created_at, completed_at
-			 FROM superboard_plugin_installation_plans WHERE plan_id = ?`,
+			`SELECT plan.plan_id, plan.instance_id, plan.target, plan.status,
+			        plan.catalog_checksum, plan.plugin_count, plan.created_at, plan.completed_at,
+			        item.plugin_id, item.state AS item_state, item.derived_contract_json,
+			        item.derived_contract_checksum, health.evidence_checksum
+			 FROM superboard_plugin_installation_plans plan
+			 LEFT JOIN superboard_plugin_installation_items item ON item.plan_id = plan.plan_id
+			 LEFT JOIN superboard_plugin_runtime_health health
+			   ON health.instance_id = plan.instance_id AND health.target = plan.target
+			  AND health.plugin_id = item.plugin_id
+			  AND health.artifact_checksum = item.artifact_checksum
+			 WHERE plan.plan_id = ? ORDER BY item.plugin_id`,
 		)
 		.bind(planId)
-		.first<{
+		.all<{
 			plan_id: string;
 			instance_id: string;
 			target: SuperBoardPluginTarget;
@@ -829,53 +1074,155 @@ async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
 			plugin_count: number;
 			created_at: string;
 			completed_at: string | null;
+			plugin_id: string | null;
+			item_state: "staged" | "installed" | "active" | "failed" | null;
+			derived_contract_json: string | null;
+			derived_contract_checksum: string | null;
+			evidence_checksum: string | null;
 		}>();
-	if (!plan) throw new Error("PLUGIN_INSTALLATION_PLAN_NOT_FOUND");
-	const items = await db
-		.prepare(
-			`SELECT plugin_id, state, derived_contract_json, derived_contract_checksum
-			 FROM superboard_plugin_installation_items
-			 WHERE plan_id = ? ORDER BY plugin_id`,
-		)
-		.bind(planId)
-		.all<{
-			plugin_id: string;
-			state: "staged" | "installed" | "active" | "failed";
-			derived_contract_json: string;
-			derived_contract_checksum: string;
-		}>();
-	const healthRows = await db
-		.prepare(
-			`SELECT plugin_id, evidence_checksum FROM superboard_plugin_runtime_health
-			 WHERE instance_id = ? AND target = ?`,
-		)
-		.bind(plan.instance_id, plan.target)
-		.all<{ plugin_id: string; evidence_checksum: string }>();
-	const health = new Map(healthRows.results.map((row) => [row.plugin_id, row.evidence_checksum]));
+	const first = result.results[0];
+	if (!first) throw new Error("PLUGIN_INSTALLATION_PLAN_NOT_FOUND");
 	const plugins = await Promise.all(
-		items.results.map(async (item) => {
-			let derived: DerivedPluginContract;
-			try {
-				derived = JSON.parse(item.derived_contract_json) as DerivedPluginContract;
-			} catch {
-				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
-			}
-			if ((await sha256Canonical(derived)) !== item.derived_contract_checksum) {
-				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
-			}
-			return {
-				plugin_id: item.plugin_id,
-				state: item.state,
-				derived,
-				derived_contract_checksum: item.derived_contract_checksum,
-				health_evidence_checksum: health.get(item.plugin_id),
-			};
-		}),
+		result.results
+			.flatMap((item) =>
+				item.plugin_id &&
+				item.item_state &&
+				item.derived_contract_json &&
+				item.derived_contract_checksum
+					? [
+							{
+								plugin_id: item.plugin_id,
+								item_state: item.item_state,
+								derived_contract_json: item.derived_contract_json,
+								derived_contract_checksum: item.derived_contract_checksum,
+								evidence_checksum: item.evidence_checksum,
+							},
+						]
+					: [],
+			)
+			.map(async (item) => {
+				let derived: DerivedPluginContract;
+				try {
+					derived = JSON.parse(item.derived_contract_json) as DerivedPluginContract;
+				} catch {
+					throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
+				}
+				if ((await sha256Canonical(derived)) !== item.derived_contract_checksum) {
+					throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_INVALID:${item.plugin_id}`);
+				}
+				return {
+					plugin_id: item.plugin_id,
+					state: item.item_state,
+					derived,
+					derived_contract_checksum: item.derived_contract_checksum,
+					health_evidence_checksum: item.evidence_checksum ?? undefined,
+				};
+			}),
 	);
 	return {
-		...plan,
+		plan_id: first.plan_id,
+		instance_id: first.instance_id,
+		target: first.target,
+		status: first.status,
+		catalog_checksum: first.catalog_checksum,
+		plugin_count: first.plugin_count,
+		created_at: first.created_at,
+		completed_at: first.completed_at,
 		plugins,
 	};
+}
+
+function installationStepsStatement(
+	db: D1Database,
+	input: PlanInput,
+	plugin: PlannedPlugin,
+): D1PreparedStatement {
+	const receipts = plugin.derived.step_receipts;
+	const healthStatus = plugin.derived.worker_status === "ready" ? "completed" : "failed";
+	return db
+		.prepare(
+			`INSERT INTO superboard_plugin_installation_steps
+			 (plan_id, plugin_id, step_name, status, receipt_checksum, completed_at)
+			 VALUES
+			 (?, ?, 'artifact_verified', 'completed', ?, ?),
+			 (?, ?, 'publisher_verified', 'completed', ?, ?),
+			 (?, ?, 'capabilities_approved', 'completed', ?, ?),
+			 (?, ?, 'stores_provisioned', 'completed', ?, ?),
+			 (?, ?, 'migration_graph_verified', 'completed', ?, ?),
+			 (?, ?, 'worker_deployed_inactive', 'completed', ?, ?),
+			 (?, ?, 'health_verified', ?, ?, ?),
+			 (?, ?, 'release_contract_ready', ?, ?, ?)`,
+		)
+		.bind(
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.artifact_verified,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.publisher_verified,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.capabilities_approved,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.stores_provisioned,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.migration_graph_verified,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			receipts.worker_deployed_inactive,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			healthStatus,
+			receipts.health_verified,
+			input.checked_at,
+			input.plan_id,
+			plugin.manifest.plugin_id,
+			healthStatus,
+			receipts.release_contract_ready,
+			input.checked_at,
+		);
+}
+
+function lifecycleEventStatement(
+	db: D1Database,
+	input: PluginScope & {
+		plugin_id: string;
+		artifact_checksum: string;
+		from_state: SuperBoardPluginLifecycleState;
+		to_state: SuperBoardPluginLifecycleState;
+		plan_id: string | null;
+		release_id: string;
+		reason: string;
+		changed_at: string;
+	},
+): D1PreparedStatement {
+	return db
+		.prepare(
+			`INSERT INTO superboard_plugin_lifecycle_events
+			 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
+			  plan_id, release_id, reason, changed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.bind(
+			input.instance_id,
+			input.target,
+			input.plugin_id,
+			input.artifact_checksum,
+			input.from_state,
+			input.to_state,
+			input.plan_id,
+			input.release_id,
+			input.reason,
+			input.changed_at,
+		);
 }
 
 function lifecycleInstallationEvents(
@@ -1000,6 +1347,7 @@ function assertPlanInput(input: PlanInput): void {
 	assertScope(input);
 	if (
 		!input.plan_id ||
+		!input.approved_by ||
 		!isCanonicalTimestamp(input.checked_at) ||
 		!isCanonicalTimestamp(input.expires_at) ||
 		Date.parse(input.expires_at) <= Date.parse(input.checked_at)

--- a/apps/site/src/lib/superboard-plugin-catalog.ts
+++ b/apps/site/src/lib/superboard-plugin-catalog.ts
@@ -203,7 +203,6 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	if (selected.length === 0 || (selectedIds && selected.length !== selectedIds.size)) {
 		throw new Error("PLUGIN_INSTALLATION_PLAN_UNKNOWN_PLUGIN");
 	}
-	await db.prepare("SELECT 1 FROM superboard_plugin_store_records LIMIT 1").first();
 	const planned = await Promise.all(selected.map((plugin) => derivePluginContract(plugin, input)));
 	const catalogChecksum = await sha256Canonical(planned.map(({ derived }) => derived.plugin_lock));
 	const unavailable = planned.filter(({ derived }) => derived.worker_status !== "ready");
@@ -374,35 +373,30 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	return loadInstallationPlanReceipt(db, input.plan_id);
 }
 
-export async function reconcileSuperBoardPluginLifecycleForRelease(
+export async function prepareSuperBoardPluginLifecycleForRelease(
 	db: D1Database,
 	input: PluginScope & {
 		release_id: string;
 		plugin_lock: readonly PluginLockEntry[];
-		activated_at: string;
+		prepared_at: string;
 	},
 ) {
 	assertScope(input);
-	if (!input.release_id || !isCanonicalTimestamp(input.activated_at)) {
-		throw new TypeError("Plugin lifecycle reconciliation requires a Release and timestamp");
+	if (!input.release_id || !isCanonicalTimestamp(input.prepared_at)) {
+		throw new TypeError("Plugin lifecycle preparation requires a Release and timestamp");
 	}
-	const activeRelease = await db
+	const candidate = await db
 		.prepare(
-			`SELECT candidate.release_json
-			 FROM superboard_front_active_releases active
-			 JOIN superboard_front_release_candidates candidate
-			   ON candidate.instance_id = active.instance_id
-			  AND candidate.release_id = active.active_release_id
-			 WHERE active.instance_id = ? AND active.active_release_id = ?
-			   AND candidate.status = 'activated'`,
+			`SELECT release_json FROM superboard_front_release_candidates
+			 WHERE instance_id = ? AND release_id = ? AND status IN ('approved', 'activated')`,
 		)
 		.bind(input.instance_id, input.release_id)
 		.first<{ release_json: string }>();
-	if (!activeRelease) throw new Error("PLUGIN_RELEASE_NOT_ACTIVE");
-	let activePluginLock: unknown;
+	if (!candidate) throw new Error("PLUGIN_RELEASE_NOT_APPROVED");
+	let candidatePluginLock: unknown;
 	try {
-		const release: unknown = JSON.parse(activeRelease.release_json);
-		activePluginLock =
+		const release: unknown = JSON.parse(candidate.release_json);
+		candidatePluginLock =
 			typeof release === "object" &&
 			release !== null &&
 			"payload" in release &&
@@ -415,7 +409,8 @@ export async function reconcileSuperBoardPluginLifecycleForRelease(
 		throw new Error("PLUGIN_RELEASE_LOCK_INVALID");
 	}
 	if (
-		canonicalizeReleasePayload(activePluginLock) !== canonicalizeReleasePayload(input.plugin_lock)
+		canonicalizeReleasePayload(candidatePluginLock) !==
+		canonicalizeReleasePayload(input.plugin_lock)
 	) {
 		throw new Error("PLUGIN_RELEASE_LOCK_MISMATCH");
 	}
@@ -436,167 +431,98 @@ export async function reconcileSuperBoardPluginLifecycleForRelease(
 		}
 	}
 	const desired = new Set(desiredLocks.map(({ plugin_id: pluginId }) => pluginId));
-	const rows = await db
+	const lifecycle = await db
 		.prepare(
-			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, lifecycle.state,
-			        lifecycle.plan_id, health.evidence_checksum, health.expires_at,
-			        json_extract(artifact.manifest_json, '$.plugin_version') AS plugin_version
-			 FROM superboard_plugin_lifecycle lifecycle
-			 JOIN superboard_plugin_manifest_artifacts artifact
-			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
-			 JOIN superboard_plugin_runtime_health health
-			   ON health.instance_id = lifecycle.instance_id
-			  AND health.target = lifecycle.target
-			  AND health.plugin_id = lifecycle.plugin_id
-			  AND health.artifact_checksum = lifecycle.artifact_checksum
-			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ?
-			 ORDER BY lifecycle.plugin_id`,
+			`SELECT plugin_id, state FROM superboard_plugin_lifecycle
+			 WHERE instance_id = ? AND target = ?
+			 ORDER BY plugin_id`,
 		)
 		.bind(input.instance_id, input.target)
-		.all<{
-			plugin_id: string;
-			artifact_checksum: string;
-			state: SuperBoardPluginLifecycleState;
-			plan_id: string | null;
-			evidence_checksum: string;
-			expires_at: string;
-			plugin_version: string;
-		}>();
-	for (const row of rows.results) {
+		.all<{ plugin_id: string; state: SuperBoardPluginLifecycleState }>();
+	for (const row of lifecycle.results) {
 		if (row.state === "active" && !desired.has(row.plugin_id)) {
 			throw new Error(`PLUGIN_RELEASE_DRAIN_REQUIRED:${row.plugin_id}`);
 		}
 	}
+	await db
+		.prepare(
+			`INSERT INTO superboard_plugin_release_reconciliations
+			 (instance_id, target, release_id, plugin_lock_json, status, prepared_at, applied_at)
+			 VALUES (?, ?, ?, ?, 'prepared', ?, NULL)
+			 ON CONFLICT(instance_id, target, release_id) DO UPDATE SET
+			   plugin_lock_json = excluded.plugin_lock_json,
+			   prepared_at = excluded.prepared_at
+			 WHERE superboard_plugin_release_reconciliations.status = 'prepared'`,
+		)
+		.bind(
+			input.instance_id,
+			input.target,
+			input.release_id,
+			canonicalizeReleasePayload(input.plugin_lock),
+			input.prepared_at,
+		)
+		.run();
+	return {
+		instance_id: input.instance_id,
+		target: input.target,
+		release_id: input.release_id,
+		status: "prepared" as const,
+		plugin_count: desiredLocks.length,
+	};
+}
 
-	const statements: D1PreparedStatement[] = [];
-	const activated: Array<{ plugin_id: string; version: string }> = [];
-	const disabled: Array<{ plugin_id: string; version: string }> = [];
-	for (const row of rows.results) {
-		if (desired.has(row.plugin_id)) {
-			if (row.state !== "installed" && row.state !== "active") {
-				throw new Error(`PLUGIN_RELEASE_STATE_INVALID:${row.plugin_id}:${row.state}`);
-			}
-			statements.push(
-				db
-					.prepare(
-						`UPDATE superboard_plugin_lifecycle
-						 SET state = 'active', activated_release_id = ?, state_changed_at = ?,
-						     reason = 'Front Release activation'
-						 WHERE instance_id = ? AND target = ? AND plugin_id = ?`,
-					)
-					.bind(
-						input.release_id,
-						input.activated_at,
-						input.instance_id,
-						input.target,
-						row.plugin_id,
-					),
-				db
-					.prepare(
-						`UPDATE superboard_plugin_installation_items
-						 SET state = 'active' WHERE plan_id = ? AND plugin_id = ?`,
-					)
-					.bind(row.plan_id, row.plugin_id),
-				db
-					.prepare(
-						`INSERT INTO superboard_active_plugin_manifests
-						 (plugin_id, artifact_checksum, activated_at)
-						 VALUES (?, ?, ?)
-						 ON CONFLICT(plugin_id) DO UPDATE SET
-						   artifact_checksum = excluded.artifact_checksum,
-						   activated_at = excluded.activated_at`,
-					)
-					.bind(row.plugin_id, row.artifact_checksum, input.activated_at),
-				db
-					.prepare(
-						`INSERT INTO superboard_dependency_health
-						 (instance_id, dependency_id, status, evidence_checksum, checked_at, expires_at)
-						 VALUES (?, ?, 'ready', ?, ?, ?)
-						 ON CONFLICT(instance_id, dependency_id) DO UPDATE SET
-						   status = 'ready', evidence_checksum = excluded.evidence_checksum,
-						   checked_at = excluded.checked_at, expires_at = excluded.expires_at`,
-					)
-					.bind(
-						input.instance_id,
-						dependencyId(row.plugin_id),
-						row.evidence_checksum,
-						input.activated_at,
-						row.expires_at,
-					),
-			);
-			if (row.state === "installed") {
-				statements.push(
-					lifecycleEventStatement(db, {
-						...input,
-						plugin_id: row.plugin_id,
-						artifact_checksum: row.artifact_checksum,
-						from_state: "installed",
-						to_state: "active",
-						plan_id: row.plan_id,
-						reason: "Front Release activation",
-						changed_at: input.activated_at,
-					}),
-				);
-			}
-			activated.push({ plugin_id: row.plugin_id, version: row.plugin_version });
-			continue;
-		}
-		if (row.state === "draining") {
-			statements.push(
-				db
-					.prepare(
-						`UPDATE superboard_plugin_lifecycle
-						 SET state = 'disabled', activated_release_id = ?, state_changed_at = ?,
-						     reason = 'Front Release removed plugin'
-						 WHERE instance_id = ? AND target = ? AND plugin_id = ? AND state = 'draining'`,
-					)
-					.bind(
-						input.release_id,
-						input.activated_at,
-						input.instance_id,
-						input.target,
-						row.plugin_id,
-					),
-				lifecycleEventStatement(db, {
-					...input,
-					plugin_id: row.plugin_id,
-					artifact_checksum: row.artifact_checksum,
-					from_state: "draining",
-					to_state: "disabled",
-					plan_id: row.plan_id,
-					reason: "Front Release removed plugin",
-					changed_at: input.activated_at,
-				}),
-				db
-					.prepare(
-						`DELETE FROM superboard_active_plugin_manifests
-						 WHERE plugin_id = ? AND artifact_checksum = ?`,
-					)
-					.bind(row.plugin_id, row.artifact_checksum),
-			);
-			disabled.push({ plugin_id: row.plugin_id, version: row.plugin_version });
-		}
+export async function finalizeSuperBoardPluginLifecycleForRelease(
+	db: D1Database,
+	input: PluginScope & { release_id: string; finalized_at: string },
+) {
+	assertScope(input);
+	if (!input.release_id || !isCanonicalTimestamp(input.finalized_at)) {
+		throw new TypeError("Plugin lifecycle finalization requires a Release and timestamp");
 	}
-	for (const installationPlanId of new Set(
-		rows.results.flatMap(({ plan_id: resolvedPlanId }) => (resolvedPlanId ? [resolvedPlanId] : [])),
-	)) {
-		statements.push(
-			db
-				.prepare(
-					`UPDATE superboard_plugin_installation_plans
-					 SET status = 'active', completed_at = ?
-					 WHERE plan_id = ? AND status = 'installed'
-					   AND NOT EXISTS (
-					     SELECT 1 FROM superboard_plugin_installation_items item
-					     WHERE item.plan_id = ? AND item.state <> 'active'
-					   )`,
-				)
-				.bind(input.activated_at, installationPlanId, installationPlanId),
-		);
+	const reconciliation = await db
+		.prepare(
+			`SELECT status FROM superboard_plugin_release_reconciliations
+			 WHERE instance_id = ? AND target = ? AND release_id = ?`,
+		)
+		.bind(input.instance_id, input.target, input.release_id)
+		.first<{ status: "prepared" | "applied" }>();
+	if (reconciliation?.status !== "applied") {
+		throw new Error("PLUGIN_RELEASE_RECONCILIATION_NOT_APPLIED");
 	}
-	await db.batch(statements);
-	await writeEmDashPluginStates(db, activated, "active", input.activated_at);
-	await writeEmDashPluginStates(db, disabled, "inactive", input.activated_at);
+	const rows = await db
+		.prepare(
+			`SELECT lifecycle.plugin_id, lifecycle.state,
+			        json_extract(artifact.manifest_json, '$.plugin_version') AS plugin_version
+			 FROM superboard_plugin_lifecycle lifecycle
+			 JOIN superboard_plugin_manifest_artifacts artifact
+			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
+			 WHERE lifecycle.instance_id = ? AND lifecycle.target = ?
+			   AND lifecycle.activated_release_id = ?
+			   AND lifecycle.state IN ('active', 'disabled')
+			 ORDER BY lifecycle.plugin_id`,
+		)
+		.bind(input.instance_id, input.target, input.release_id)
+		.all<{ plugin_id: string; state: "active" | "disabled"; plugin_version: string }>();
+	const activated = rows.results.filter(({ state }) => state === "active");
+	const disabled = rows.results.filter(({ state }) => state === "disabled");
+	await writeEmDashPluginStates(
+		db,
+		activated.map(({ plugin_id: pluginId, plugin_version: version }) => ({
+			plugin_id: pluginId,
+			version,
+		})),
+		"active",
+		input.finalized_at,
+	);
+	await writeEmDashPluginStates(
+		db,
+		disabled.map(({ plugin_id: pluginId, plugin_version: version }) => ({
+			plugin_id: pluginId,
+			version,
+		})),
+		"inactive",
+		input.finalized_at,
+	);
 	return {
 		instance_id: input.instance_id,
 		target: input.target,
@@ -799,7 +725,7 @@ async function loadSuperBoardPluginLock(
 	const result = await db
 		.prepare(
 			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, artifact.manifest_json,
-			        lifecycle.state, health.status AS health_status,
+			        lifecycle.state, health.status AS health_status, health.expires_at,
 			        item.derived_contract_json, item.derived_contract_checksum,
 			        steps.step_count, steps.completed_count
 			 FROM superboard_plugin_lifecycle lifecycle
@@ -829,6 +755,7 @@ async function loadSuperBoardPluginLock(
 			manifest_json: string;
 			state: "installed" | "active";
 			health_status: "ready" | "unavailable";
+			expires_at: string;
 			derived_contract_json: string | null;
 			derived_contract_checksum: string | null;
 			step_count: number | null;
@@ -847,7 +774,7 @@ async function loadSuperBoardPluginLock(
 	);
 	return Promise.all(
 		rows.map(async (row) => {
-			if (row.health_status !== "ready") {
+			if (row.health_status !== "ready" || Date.parse(row.expires_at) <= Date.now()) {
 				throw new Error(`PLUGIN_CATALOG_HEALTH_NOT_READY:${row.plugin_id}`);
 			}
 			if (!row.derived_contract_json || !row.derived_contract_checksum) {
@@ -1188,40 +1115,6 @@ function installationStepsStatement(
 			healthStatus,
 			receipts.release_contract_ready,
 			input.checked_at,
-		);
-}
-
-function lifecycleEventStatement(
-	db: D1Database,
-	input: PluginScope & {
-		plugin_id: string;
-		artifact_checksum: string;
-		from_state: SuperBoardPluginLifecycleState;
-		to_state: SuperBoardPluginLifecycleState;
-		plan_id: string | null;
-		release_id: string;
-		reason: string;
-		changed_at: string;
-	},
-): D1PreparedStatement {
-	return db
-		.prepare(
-			`INSERT INTO superboard_plugin_lifecycle_events
-			 (instance_id, target, plugin_id, artifact_checksum, from_state, to_state,
-			  plan_id, release_id, reason, changed_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		)
-		.bind(
-			input.instance_id,
-			input.target,
-			input.plugin_id,
-			input.artifact_checksum,
-			input.from_state,
-			input.to_state,
-			input.plan_id,
-			input.release_id,
-			input.reason,
-			input.changed_at,
 		);
 }
 

--- a/apps/site/src/lib/superboard-plugin-catalog.ts
+++ b/apps/site/src/lib/superboard-plugin-catalog.ts
@@ -41,6 +41,8 @@ interface PluginScope {
 interface PlanInput extends PluginScope {
 	plan_id: string;
 	approved_by: string;
+	target_artifact_checksum: string;
+	target_plugin_ids: readonly string[];
 	checked_at: string;
 	expires_at: string;
 	plugin_ids?: readonly string[];
@@ -89,6 +91,7 @@ const compatibility = compatibilityJson as {
 	artifacts: Record<string, { plugin_id: string; manifest_checksum: string }>;
 };
 const MISSING_PLUGIN_STATE_TABLE_PATTERN = /no such table:\s*_plugin_state/iu;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 const TARGETS = new Set<SuperBoardPluginTarget>(["local", "development", "production"]);
 const LIFECYCLE_TRANSITIONS: Record<
 	SuperBoardPluginLifecycleState,
@@ -109,6 +112,24 @@ export function resolveSuperBoardPluginTarget(value: unknown): SuperBoardPluginT
 		return value as SuperBoardPluginTarget;
 	}
 	throw new TypeError("Plugin lifecycle requires a valid target");
+}
+
+export function resolveSuperBoardTargetPluginIds(value: unknown): string[] {
+	if (typeof value !== "string") throw new TypeError("Target plugin selection is unavailable");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		throw new TypeError("Target plugin selection is invalid");
+	}
+	if (
+		!Array.isArray(parsed) ||
+		parsed.length === 0 ||
+		parsed.some((pluginId) => typeof pluginId !== "string" || pluginId.includes("*"))
+	) {
+		throw new TypeError("Target plugin selection is invalid");
+	}
+	return parsed;
 }
 
 export function resolveSuperBoardPluginLifecycleState(
@@ -156,13 +177,22 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	assertPlanInput(input);
 	const existing = await db
 		.prepare(
-			`SELECT instance_id, target FROM superboard_plugin_installation_plans
+			`SELECT instance_id, target, target_artifact_checksum
+			 FROM superboard_plugin_installation_plans
 			 WHERE plan_id = ?`,
 		)
 		.bind(input.plan_id)
-		.first<{ instance_id: string; target: SuperBoardPluginTarget }>();
+		.first<{
+			instance_id: string;
+			target: SuperBoardPluginTarget;
+			target_artifact_checksum: string;
+		}>();
 	if (existing) {
-		if (existing.instance_id !== input.instance_id || existing.target !== input.target) {
+		if (
+			existing.instance_id !== input.instance_id ||
+			existing.target !== input.target ||
+			existing.target_artifact_checksum !== input.target_artifact_checksum
+		) {
 			throw new Error("PLUGIN_INSTALLATION_PLAN_SCOPE_MISMATCH");
 		}
 		const receipt = await loadInstallationPlanReceipt(db, input.plan_id);
@@ -196,12 +226,34 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	}
 
 	const catalog = superBoardRuntimePluginCatalog();
-	const selectedIds = input.plugin_ids ? new Set(input.plugin_ids) : null;
-	const selected = selectedIds
-		? catalog.plugins.filter(({ manifest }) => selectedIds.has(manifest.plugin_id))
-		: catalog.plugins;
-	if (selected.length === 0 || (selectedIds && selected.length !== selectedIds.size)) {
+	const catalogIds = new Set(catalog.plugins.map(({ manifest }) => manifest.plugin_id));
+	const targetIds = new Set(input.target_plugin_ids);
+	if (
+		targetIds.size === 0 ||
+		targetIds.size !== input.target_plugin_ids.length ||
+		[...targetIds].some((pluginId) => !catalogIds.has(pluginId))
+	) {
+		throw new Error("PLUGIN_TARGET_ARTIFACT_INVALID");
+	}
+	const selectedIds = input.plugin_ids ? new Set(input.plugin_ids) : targetIds;
+	if ([...selectedIds].some((pluginId) => !targetIds.has(pluginId))) {
+		throw new Error("PLUGIN_INSTALLATION_PLAN_PLUGIN_NOT_IN_TARGET");
+	}
+	const selected = catalog.plugins.filter(({ manifest }) => selectedIds.has(manifest.plugin_id));
+	if (selected.length === 0 || selected.length !== selectedIds.size) {
 		throw new Error("PLUGIN_INSTALLATION_PLAN_UNKNOWN_PLUGIN");
+	}
+	const available = catalog.plugins.filter(({ manifest }) => !selectedIds.has(manifest.plugin_id));
+	for (const { manifest } of available) {
+		const verification =
+			manifest.plugin_id === userPluginManifest.plugin_id
+				? await validateUserPluginManifest(manifest)
+				: await verifySuperBoardPluginManifest(manifest);
+		if (!verification.valid) {
+			throw new Error(
+				`${manifest.plugin_id} manifest is invalid: ${verification.errors.join(",")}`,
+			);
+		}
 	}
 	const planned = await Promise.all(selected.map((plugin) => derivePluginContract(plugin, input)));
 	const catalogChecksum = await sha256Canonical(planned.map(({ derived }) => derived.plugin_lock));
@@ -225,15 +277,33 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 	const statements: D1PreparedStatement[] = [
 		db
 			.prepare(
+				`INSERT INTO superboard_plugin_target_artifacts
+				 (instance_id, target, artifact_checksum, plugin_ids_json, registered_at)
+				 VALUES (?, ?, ?, ?, ?)
+				 ON CONFLICT(instance_id, target) DO UPDATE SET
+				   artifact_checksum = excluded.artifact_checksum,
+				   plugin_ids_json = excluded.plugin_ids_json,
+				   registered_at = excluded.registered_at`,
+			)
+			.bind(
+				input.instance_id,
+				input.target,
+				input.target_artifact_checksum,
+				canonicalizeReleasePayload([...targetIds].toSorted()),
+				input.checked_at,
+			),
+		db
+			.prepare(
 				`INSERT INTO superboard_plugin_installation_plans
-				 (plan_id, instance_id, target, status, catalog_checksum, plugin_count,
-				  created_at, completed_at, failure_json)
-				 VALUES (?, ?, ?, 'installing', ?, ?, ?, NULL, NULL)`,
+				 (plan_id, instance_id, target, target_artifact_checksum, status,
+				  catalog_checksum, plugin_count, created_at, completed_at, failure_json)
+				 VALUES (?, ?, ?, ?, 'installing', ?, ?, ?, NULL, NULL)`,
 			)
 			.bind(
 				input.plan_id,
 				input.instance_id,
 				input.target,
+				input.target_artifact_checksum,
 				catalogChecksum,
 				planned.length,
 				input.checked_at,
@@ -331,6 +401,38 @@ export async function installSuperBoardPluginCatalog(db: D1Database, input: Plan
 				current_state: currentState,
 				to_state: nextState,
 			}),
+		);
+	}
+	for (const { manifest } of available) {
+		statements.push(
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_manifest_artifacts
+					 (artifact_checksum, plugin_id, manifest_json, installed_at)
+					 VALUES (?, ?, ?, ?)
+					 ON CONFLICT(artifact_checksum) DO NOTHING`,
+				)
+				.bind(
+					manifest.artifact_checksum,
+					manifest.plugin_id,
+					canonicalizeReleasePayload(manifest),
+					input.checked_at,
+				),
+			db
+				.prepare(
+					`INSERT INTO superboard_plugin_lifecycle
+					 (instance_id, target, plugin_id, artifact_checksum, state, plan_id,
+					  state_changed_at, reason)
+					 VALUES (?, ?, ?, ?, 'available', NULL, ?, 'target catalog')
+					 ON CONFLICT(instance_id, target, plugin_id) DO NOTHING`,
+				)
+				.bind(
+					input.instance_id,
+					input.target,
+					manifest.plugin_id,
+					manifest.artifact_checksum,
+					input.checked_at,
+				),
 		);
 	}
 	statements.push(
@@ -447,9 +549,13 @@ export async function prepareSuperBoardPluginLifecycleForRelease(
 	await db
 		.prepare(
 			`INSERT INTO superboard_plugin_release_reconciliations
-			 (instance_id, target, release_id, plugin_lock_json, status, prepared_at, applied_at)
-			 VALUES (?, ?, ?, ?, 'prepared', ?, NULL)
+			 (instance_id, target, release_id, target_artifact_checksum,
+			  plugin_lock_json, status, prepared_at, applied_at)
+			 SELECT ?, ?, ?, target_artifact.artifact_checksum, ?, 'prepared', ?, NULL
+			 FROM superboard_plugin_target_artifacts target_artifact
+			 WHERE target_artifact.instance_id = ? AND target_artifact.target = ?
 			 ON CONFLICT(instance_id, target, release_id) DO UPDATE SET
+			   target_artifact_checksum = excluded.target_artifact_checksum,
 			   plugin_lock_json = excluded.plugin_lock_json,
 			   prepared_at = excluded.prepared_at
 			 WHERE superboard_plugin_release_reconciliations.status = 'prepared'`,
@@ -460,6 +566,8 @@ export async function prepareSuperBoardPluginLifecycleForRelease(
 			input.release_id,
 			canonicalizeReleasePayload(input.plugin_lock),
 			input.prepared_at,
+			input.instance_id,
+			input.target,
 		)
 		.run();
 	return {
@@ -484,6 +592,10 @@ export async function finalizeSuperBoardPluginLifecycleForRelease(
 			`SELECT reconciliation.status, reconciliation.plugin_lock_json,
 			        active.active_release_id
 			 FROM superboard_plugin_release_reconciliations reconciliation
+			 JOIN superboard_plugin_target_artifacts target_artifact
+			   ON target_artifact.instance_id = reconciliation.instance_id
+			  AND target_artifact.target = reconciliation.target
+			  AND target_artifact.artifact_checksum = reconciliation.target_artifact_checksum
 			 LEFT JOIN superboard_front_active_releases active
 			   ON active.instance_id = reconciliation.instance_id
 			  AND active.active_release_id = reconciliation.release_id
@@ -716,6 +828,8 @@ export async function synchronizeSuperBoardPluginCatalog(
 		target?: SuperBoardPluginTarget;
 		plan_id?: string;
 		approved_by: string;
+		target_artifact_checksum: string;
+		target_plugin_ids: readonly string[];
 		checked_at: string;
 		expires_at: string;
 	},
@@ -725,6 +839,8 @@ export async function synchronizeSuperBoardPluginCatalog(
 		...scope,
 		plan_id: input.plan_id ?? `plugin-plan-${crypto.randomUUID()}`,
 		approved_by: input.approved_by,
+		target_artifact_checksum: input.target_artifact_checksum,
+		target_plugin_ids: input.target_plugin_ids,
 		checked_at: input.checked_at,
 		expires_at: input.expires_at,
 	});
@@ -765,7 +881,8 @@ async function loadSuperBoardPluginLock(
 			`SELECT lifecycle.plugin_id, lifecycle.artifact_checksum, artifact.manifest_json,
 			        lifecycle.state, health.status AS health_status, health.expires_at,
 			        item.derived_contract_json, item.derived_contract_checksum,
-			        steps.step_count, steps.completed_count
+			        steps.step_count, steps.completed_count,
+			        target_artifact.artifact_checksum AS target_artifact_checksum
 			 FROM superboard_plugin_lifecycle lifecycle
 			 JOIN superboard_plugin_manifest_artifacts artifact
 			   ON artifact.artifact_checksum = lifecycle.artifact_checksum
@@ -777,6 +894,11 @@ async function loadSuperBoardPluginLock(
 			 LEFT JOIN superboard_plugin_installation_items item
 			   ON item.plan_id = lifecycle.plan_id AND item.plugin_id = lifecycle.plugin_id
 			  AND item.artifact_checksum = lifecycle.artifact_checksum
+			 LEFT JOIN superboard_plugin_installation_plans plan ON plan.plan_id = item.plan_id
+			 LEFT JOIN superboard_plugin_target_artifacts target_artifact
+			   ON target_artifact.instance_id = lifecycle.instance_id
+			  AND target_artifact.target = lifecycle.target
+			  AND target_artifact.artifact_checksum = plan.target_artifact_checksum
 			 LEFT JOIN (
 			   SELECT plan_id, plugin_id, COUNT(*) AS step_count,
 			          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count
@@ -798,6 +920,7 @@ async function loadSuperBoardPluginLock(
 			derived_contract_checksum: string | null;
 			step_count: number | null;
 			completed_count: number | null;
+			target_artifact_checksum: string | null;
 		}>();
 	const rows = includeInstalled
 		? result.results
@@ -817,6 +940,9 @@ async function loadSuperBoardPluginLock(
 			}
 			if (!row.derived_contract_json || !row.derived_contract_checksum) {
 				throw new Error(`PLUGIN_INSTALLATION_PLAN_CONTRACT_MISSING:${row.plugin_id}`);
+			}
+			if (!row.target_artifact_checksum) {
+				throw new Error(`PLUGIN_TARGET_ARTIFACT_MISMATCH:${row.plugin_id}`);
 			}
 			if (row.step_count !== 8 || row.completed_count !== 8) {
 				throw new Error(`PLUGIN_INSTALLATION_PLAN_STEPS_INCOMPLETE:${row.plugin_id}`);
@@ -924,6 +1050,7 @@ async function derivePluginContract(
 			: ("unavailable" as const);
 	const capabilities = manifest.capabilities.toSorted();
 	const capabilityApprovalChecksum = await sha256Canonical({
+		target_artifact_checksum: input.target_artifact_checksum,
 		plugin_id: manifest.plugin_id,
 		artifact_checksum: manifest.artifact_checksum,
 		capabilities,
@@ -949,6 +1076,7 @@ async function derivePluginContract(
 	const stepReceipts: Record<PluginInstallationStep, string> = {
 		artifact_verified: await sha256Canonical({
 			domain: "superboard.plugin_installation.artifact_verified.v1",
+			target_artifact_checksum: input.target_artifact_checksum,
 			artifact_id: manifest.artifact_id,
 			artifact_checksum: manifest.artifact_checksum,
 		}),
@@ -960,11 +1088,13 @@ async function derivePluginContract(
 		capabilities_approved: capabilityApprovalChecksum,
 		stores_provisioned: await sha256Canonical({
 			domain: "superboard.plugin_installation.stores_provisioned.v1",
+			target_artifact_checksum: input.target_artifact_checksum,
 			stores,
 		}),
 		migration_graph_verified: migrationsChecksum,
 		worker_deployed_inactive: await sha256Canonical({
 			domain: "superboard.plugin_installation.worker_deployed_inactive.v1",
+			target_artifact_checksum: input.target_artifact_checksum,
 			worker_descriptor_checksum: workerDescriptorChecksum,
 			contributions_active: false,
 		}),
@@ -977,6 +1107,7 @@ async function derivePluginContract(
 		}),
 		release_contract_ready: await sha256Canonical({
 			domain: "superboard.plugin_installation.release_contract_ready.v1",
+			target_artifact_checksum: input.target_artifact_checksum,
 			plugin_lock: pluginLock,
 			settings_checksum: settingsChecksum,
 			contributions_checksum: contributionsChecksum,
@@ -1001,6 +1132,7 @@ async function derivePluginContract(
 		derived_contract_checksum: await sha256Canonical(derived),
 		health_evidence_checksum: await sha256Canonical({
 			domain: "superboard.plugin_runtime_health.v1",
+			target_artifact_checksum: input.target_artifact_checksum,
 			instance_id: input.instance_id,
 			target: input.target,
 			plugin_id: manifest.plugin_id,
@@ -1017,7 +1149,8 @@ async function derivePluginContract(
 async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
 	const result = await db
 		.prepare(
-			`SELECT plan.plan_id, plan.instance_id, plan.target, plan.status,
+			`SELECT plan.plan_id, plan.instance_id, plan.target, plan.target_artifact_checksum,
+			        plan.status,
 			        plan.catalog_checksum, plan.plugin_count, plan.created_at, plan.completed_at,
 			        item.plugin_id, item.state AS item_state, item.derived_contract_json,
 			        item.derived_contract_checksum, health.evidence_checksum
@@ -1034,6 +1167,7 @@ async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
 			plan_id: string;
 			instance_id: string;
 			target: SuperBoardPluginTarget;
+			target_artifact_checksum: string;
 			status: "installing" | "installed" | "active" | "failed";
 			catalog_checksum: string;
 			plugin_count: number;
@@ -1088,6 +1222,7 @@ async function loadInstallationPlanReceipt(db: D1Database, planId: string) {
 		plan_id: first.plan_id,
 		instance_id: first.instance_id,
 		target: first.target,
+		target_artifact_checksum: first.target_artifact_checksum,
 		status: first.status,
 		catalog_checksum: first.catalog_checksum,
 		plugin_count: first.plugin_count,
@@ -1279,6 +1414,7 @@ function assertPlanInput(input: PlanInput): void {
 	if (
 		!input.plan_id ||
 		!input.approved_by ||
+		!SHA256_PATTERN.test(input.target_artifact_checksum) ||
 		!isCanonicalTimestamp(input.checked_at) ||
 		!isCanonicalTimestamp(input.expires_at) ||
 		Date.parse(input.expires_at) <= Date.parse(input.checked_at)

--- a/apps/site/src/lib/user-plugin-installation.ts
+++ b/apps/site/src/lib/user-plugin-installation.ts
@@ -1,7 +1,6 @@
 import { userPluginManifest } from "@superboard/supbrd-plug-user";
 
 import {
-	activateSuperBoardPluginInstallationPlan,
 	installSuperBoardPluginCatalog,
 	type SuperBoardPluginTarget,
 } from "./superboard-plugin-catalog.js";
@@ -13,6 +12,7 @@ export async function installCompiledUserPlugin(
 	input: {
 		instance_id: string;
 		target?: SuperBoardPluginTarget;
+		approved_by: string;
 		checked_at: string;
 		expires_at: string;
 	},
@@ -24,12 +24,6 @@ export async function installCompiledUserPlugin(
 		plan_id: `user-plugin-plan-${crypto.randomUUID()}`,
 		plugin_ids: [userPluginManifest.plugin_id],
 	});
-	await activateSuperBoardPluginInstallationPlan(db, {
-		instance_id: input.instance_id,
-		target,
-		plan_id: plan.plan_id,
-		changed_at: input.checked_at,
-	});
 	const plugin = plan.plugins[0];
 	if (!plugin) throw new Error("USER_PLUGIN_INSTALLATION_PLAN_EMPTY");
 	return {
@@ -40,7 +34,7 @@ export async function installCompiledUserPlugin(
 		plugin_version: userPluginManifest.plugin_version,
 		artifact_checksum: userPluginManifest.artifact_checksum,
 		activation_scope: "front_release" as const,
-		status: "ready" as const,
+		status: "installed" as const,
 		checked_at: input.checked_at,
 		expires_at: input.expires_at,
 		evidence_checksum: plugin.health_evidence_checksum,

--- a/apps/site/src/lib/user-plugin-installation.ts
+++ b/apps/site/src/lib/user-plugin-installation.ts
@@ -13,6 +13,8 @@ export async function installCompiledUserPlugin(
 		instance_id: string;
 		target?: SuperBoardPluginTarget;
 		approved_by: string;
+		target_artifact_checksum: string;
+		target_plugin_ids: readonly string[];
 		checked_at: string;
 		expires_at: string;
 	},

--- a/apps/site/src/lib/user-plugin-installation.ts
+++ b/apps/site/src/lib/user-plugin-installation.ts
@@ -1,30 +1,40 @@
-import { canonicalizeReleasePayload, sha256Canonical } from "@superboard/supbrd-core";
+import { userPluginManifest } from "@superboard/supbrd-plug-user";
+
 import {
-	userPluginManifest,
-	validateUserPluginManifest,
-} from "@superboard/supbrd-plug-user";
+	activateSuperBoardPluginInstallationPlan,
+	installSuperBoardPluginCatalog,
+	type SuperBoardPluginTarget,
+} from "./superboard-plugin-catalog.js";
 
 const USER_DEPENDENCY_ID = "dependency.supbrd_plug_user";
 
 export async function installCompiledUserPlugin(
 	db: D1Database,
-	input: { instance_id: string; checked_at: string; expires_at: string },
+	input: {
+		instance_id: string;
+		target?: SuperBoardPluginTarget;
+		checked_at: string;
+		expires_at: string;
+	},
 ) {
-	if (
-		!input.instance_id ||
-		!isCanonicalTimestamp(input.checked_at) ||
-		!isCanonicalTimestamp(input.expires_at) ||
-		Date.parse(input.expires_at) <= Date.parse(input.checked_at)
-	) {
-		throw new TypeError("Compiled user plugin installation requires a bounded validity window");
-	}
-	const verification = await validateUserPluginManifest(userPluginManifest);
-	if (!verification.valid) {
-		throw new Error(`Compiled user plugin manifest is invalid: ${verification.errors.join(",")}`);
-	}
-	const evidence = {
-		domain: "superboard.dependency_health.v1",
+	const target = input.target ?? "local";
+	const plan = await installSuperBoardPluginCatalog(db, {
+		...input,
+		target,
+		plan_id: `user-plugin-plan-${crypto.randomUUID()}`,
+		plugin_ids: [userPluginManifest.plugin_id],
+	});
+	await activateSuperBoardPluginInstallationPlan(db, {
 		instance_id: input.instance_id,
+		target,
+		plan_id: plan.plan_id,
+		changed_at: input.checked_at,
+	});
+	const plugin = plan.plugins[0];
+	if (!plugin) throw new Error("USER_PLUGIN_INSTALLATION_PLAN_EMPTY");
+	return {
+		instance_id: input.instance_id,
+		target,
 		dependency_id: USER_DEPENDENCY_ID,
 		plugin_id: userPluginManifest.plugin_id,
 		plugin_version: userPluginManifest.plugin_version,
@@ -33,59 +43,7 @@ export async function installCompiledUserPlugin(
 		status: "ready" as const,
 		checked_at: input.checked_at,
 		expires_at: input.expires_at,
+		evidence_checksum: plugin.health_evidence_checksum,
+		plan_id: plan.plan_id,
 	};
-	const evidenceChecksum = await sha256Canonical(evidence);
-	const manifestJson = canonicalizeReleasePayload(userPluginManifest);
-	await db.batch([
-		db
-			.prepare(
-				`INSERT INTO superboard_plugin_manifest_artifacts
-				 (artifact_checksum, plugin_id, manifest_json, installed_at)
-				 VALUES (?, ?, ?, ?)
-				 ON CONFLICT(artifact_checksum) DO NOTHING`,
-			)
-			.bind(
-				userPluginManifest.artifact_checksum,
-				userPluginManifest.plugin_id,
-				manifestJson,
-				input.checked_at,
-			),
-		db
-			.prepare(
-				`INSERT INTO superboard_active_plugin_manifests
-				 (plugin_id, artifact_checksum, activated_at)
-				 VALUES (?, ?, ?)
-				 ON CONFLICT(plugin_id) DO UPDATE SET
-				   artifact_checksum = excluded.artifact_checksum,
-				   activated_at = excluded.activated_at`,
-			)
-			.bind(
-				userPluginManifest.plugin_id,
-				userPluginManifest.artifact_checksum,
-				input.checked_at,
-			),
-		db
-			.prepare(
-				`INSERT INTO superboard_dependency_health
-				 (instance_id, dependency_id, status, evidence_checksum, checked_at, expires_at)
-				 VALUES (?, ?, 'ready', ?, ?, ?)
-				 ON CONFLICT(instance_id, dependency_id) DO UPDATE SET
-				   status = excluded.status,
-				   evidence_checksum = excluded.evidence_checksum,
-				   checked_at = excluded.checked_at,
-				   expires_at = excluded.expires_at`,
-			)
-			.bind(
-				input.instance_id,
-				USER_DEPENDENCY_ID,
-				evidenceChecksum,
-				input.checked_at,
-				input.expires_at,
-			),
-	]);
-	return { ...evidence, evidence_checksum: evidenceChecksum };
-}
-
-function isCanonicalTimestamp(value: string): boolean {
-	return !Number.isNaN(Date.parse(value)) && new Date(value).toISOString() === value;
 }

--- a/apps/site/src/pages/_superboard/api/plugins/[pluginId]/lifecycle.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/[pluginId]/lifecycle.ts
@@ -22,18 +22,19 @@ export const POST: APIRoute = async (context) => {
 		if (!isRecord(body) || !pluginId || typeof body.reason !== "string" || !body.reason.trim()) {
 			return jsonResponse({ error: { code: "INVALID_PLUGIN_LIFECYCLE_REQUEST" } }, 422);
 		}
+		const state = resolveSuperBoardPluginLifecycleState(body.state);
+		if (state === "active" || state === "disabled") {
+			return jsonResponse({ error: { code: "RELEASE_MANAGED_PLUGIN_STATE" } }, 422);
+		}
 		const result = await transitionSuperBoardPluginLifecycle(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
 			plugin_id: pluginId,
-			to_state: resolveSuperBoardPluginLifecycleState(body.state),
+			to_state: state,
 			changed_at: new Date().toISOString(),
 			reason: body.reason,
 		});
-		await context.locals.emdash.setPluginStatus(
-			pluginId,
-			result.state === "active" ? "active" : "inactive",
-		);
+		await context.locals.emdash.setPluginStatus(pluginId, "inactive");
 		return jsonResponse(result, 200);
 	} catch (error) {
 		return handleError(

--- a/apps/site/src/pages/_superboard/api/plugins/[pluginId]/lifecycle.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/[pluginId]/lifecycle.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from "astro";
+import { handleError } from "emdash/api/error";
+
+import { jsonResponse, requireReleaseOperator } from "../../../../../lib/operator-guard.js";
+import { isRecord } from "../../../../../lib/request-validation.js";
+import { getSiteEnv } from "../../../../../lib/site-env.js";
+import {
+	resolveSuperBoardPluginLifecycleState,
+	resolveSuperBoardPluginTarget,
+	transitionSuperBoardPluginLifecycle,
+} from "../../../../../lib/superboard-plugin-catalog.js";
+
+export const prerender = false;
+
+export const POST: APIRoute = async (context) => {
+	const env = getSiteEnv();
+	const denied = requireReleaseOperator(context, env);
+	if (denied) return denied;
+	try {
+		const body: unknown = await context.request.json();
+		const pluginId = context.params.pluginId;
+		if (!isRecord(body) || !pluginId || typeof body.reason !== "string" || !body.reason.trim()) {
+			return jsonResponse({ error: { code: "INVALID_PLUGIN_LIFECYCLE_REQUEST" } }, 422);
+		}
+		const result = await transitionSuperBoardPluginLifecycle(env.DB, {
+			instance_id: env.SUPERBOARD_INSTANCE_ID,
+			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
+			plugin_id: pluginId,
+			to_state: resolveSuperBoardPluginLifecycleState(body.state),
+			changed_at: new Date().toISOString(),
+			reason: body.reason,
+		});
+		await context.locals.emdash.setPluginStatus(
+			pluginId,
+			result.state === "active" ? "active" : "inactive",
+		);
+		return jsonResponse(result, 200);
+	} catch (error) {
+		return handleError(
+			error,
+			"SuperBoard plugin lifecycle transition failed",
+			"PLUGIN_LIFECYCLE_TRANSITION_FAILED",
+		);
+	}
+};

--- a/apps/site/src/pages/_superboard/api/plugins/sync.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/sync.ts
@@ -7,6 +7,7 @@ import { getSiteEnv } from "../../../../lib/site-env.js";
 import {
 	installSuperBoardPluginCatalog,
 	resolveSuperBoardPluginTarget,
+	resolveSuperBoardTargetPluginIds,
 } from "../../../../lib/superboard-plugin-catalog.js";
 
 export const prerender = false;
@@ -41,6 +42,8 @@ export const POST: APIRoute = async (context) => {
 			plan_id:
 				typeof body.plan_id === "string" ? body.plan_id : `plugin-plan-${crypto.randomUUID()}`,
 			approved_by: operatorId,
+			target_artifact_checksum: env.TARGET_ARTIFACT_CHECKSUM,
+			target_plugin_ids: resolveSuperBoardTargetPluginIds(env.SUPERBOARD_PLUGIN_IDS),
 			checked_at: checkedAt,
 			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});

--- a/apps/site/src/pages/_superboard/api/plugins/sync.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/sync.ts
@@ -5,7 +5,6 @@ import { jsonResponse, requireReleaseOperator } from "../../../../lib/operator-g
 import { isRecord } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
 import {
-	activateSuperBoardPluginInstallationPlan,
 	installSuperBoardPluginCatalog,
 	resolveSuperBoardPluginTarget,
 } from "../../../../lib/superboard-plugin-catalog.js";
@@ -27,36 +26,25 @@ export const POST: APIRoute = async (context) => {
 			!Number.isSafeInteger(expiresInHours) ||
 			expiresInHours < 1 ||
 			expiresInHours > 24 ||
-			(body.activate !== undefined && typeof body.activate !== "boolean") ||
+			body.activate !== undefined ||
 			(body.plan_id !== undefined && (typeof body.plan_id !== "string" || !body.plan_id.trim()))
 		) {
 			return jsonResponse({ error: { code: "INVALID_PLUGIN_CATALOG_SYNC_REQUEST" } }, 422);
 		}
 		const checkedAt = new Date().toISOString();
+		const operatorId = context.locals.user?.id;
+		if (!operatorId) return jsonResponse({ error: { code: "UNAUTHORIZED" } }, 401);
 		const target = resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local");
 		const plan = await installSuperBoardPluginCatalog(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			target,
 			plan_id:
 				typeof body.plan_id === "string" ? body.plan_id : `plugin-plan-${crypto.randomUUID()}`,
+			approved_by: operatorId,
 			checked_at: checkedAt,
 			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});
-		const activation =
-			body.activate === true
-				? await activateSuperBoardPluginInstallationPlan(env.DB, {
-						instance_id: env.SUPERBOARD_INSTANCE_ID,
-						target,
-						plan_id: plan.plan_id,
-						changed_at: checkedAt,
-					})
-				: null;
-		if (activation) {
-			for (const plugin of plan.plugins) {
-				await context.locals.emdash.setPluginStatus(plugin.plugin_id, "active");
-			}
-		}
-		return jsonResponse({ plan, activation }, 201);
+		return jsonResponse({ plan }, 201);
 	} catch (error) {
 		return handleError(
 			error,

--- a/apps/site/src/pages/_superboard/api/plugins/sync.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/sync.ts
@@ -4,7 +4,11 @@ import { handleError } from "emdash/api/error";
 import { jsonResponse, requireReleaseOperator } from "../../../../lib/operator-guard.js";
 import { isRecord } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
-import { synchronizeSuperBoardPluginCatalog } from "../../../../lib/superboard-plugin-catalog.js";
+import {
+	activateSuperBoardPluginInstallationPlan,
+	installSuperBoardPluginCatalog,
+	resolveSuperBoardPluginTarget,
+} from "../../../../lib/superboard-plugin-catalog.js";
 
 export const prerender = false;
 
@@ -22,19 +26,37 @@ export const POST: APIRoute = async (context) => {
 			typeof expiresInHours !== "number" ||
 			!Number.isSafeInteger(expiresInHours) ||
 			expiresInHours < 1 ||
-			expiresInHours > 24
+			expiresInHours > 24 ||
+			(body.activate !== undefined && typeof body.activate !== "boolean") ||
+			(body.plan_id !== undefined && (typeof body.plan_id !== "string" || !body.plan_id.trim()))
 		) {
 			return jsonResponse({ error: { code: "INVALID_PLUGIN_CATALOG_SYNC_REQUEST" } }, 422);
 		}
 		const checkedAt = new Date().toISOString();
-		const result = await synchronizeSuperBoardPluginCatalog(env.DB, {
+		const target = resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local");
+		const plan = await installSuperBoardPluginCatalog(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
+			target,
+			plan_id:
+				typeof body.plan_id === "string" ? body.plan_id : `plugin-plan-${crypto.randomUUID()}`,
 			checked_at: checkedAt,
-			expires_at: new Date(
-				Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000,
-			).toISOString(),
+			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});
-		return jsonResponse(result, 201);
+		const activation =
+			body.activate === true
+				? await activateSuperBoardPluginInstallationPlan(env.DB, {
+						instance_id: env.SUPERBOARD_INSTANCE_ID,
+						target,
+						plan_id: plan.plan_id,
+						changed_at: checkedAt,
+					})
+				: null;
+		if (activation) {
+			for (const plugin of plan.plugins) {
+				await context.locals.emdash.setPluginStatus(plugin.plugin_id, "active");
+			}
+		}
+		return jsonResponse({ plan, activation }, 201);
 	} catch (error) {
 		return handleError(
 			error,

--- a/apps/site/src/pages/_superboard/api/plugins/user/install.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/user/install.ts
@@ -4,6 +4,7 @@ import { handleError } from "emdash/api/error";
 import { jsonResponse, requireReleaseOperator } from "../../../../../lib/operator-guard.js";
 import { isRecord } from "../../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../../lib/site-env.js";
+import { resolveSuperBoardPluginTarget } from "../../../../../lib/superboard-plugin-catalog.js";
 import { installCompiledUserPlugin } from "../../../../../lib/user-plugin-installation.js";
 
 export const prerender = false;
@@ -29,11 +30,11 @@ export const POST: APIRoute = async (context) => {
 		const checkedAt = new Date().toISOString();
 		const receipt = await installCompiledUserPlugin(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
+			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
 			checked_at: checkedAt,
-			expires_at: new Date(
-				Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000,
-			).toISOString(),
+			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});
+		await context.locals.emdash.setPluginStatus(receipt.plugin_id, "active");
 		return jsonResponse(receipt, 201);
 	} catch (error) {
 		return handleError(

--- a/apps/site/src/pages/_superboard/api/plugins/user/install.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/user/install.ts
@@ -28,13 +28,15 @@ export const POST: APIRoute = async (context) => {
 			return jsonResponse({ error: { code: "INVALID_USER_PLUGIN_INSTALL_REQUEST" } }, 422);
 		}
 		const checkedAt = new Date().toISOString();
+		const operatorId = context.locals.user?.id;
+		if (!operatorId) return jsonResponse({ error: { code: "UNAUTHORIZED" } }, 401);
 		const receipt = await installCompiledUserPlugin(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
+			approved_by: operatorId,
 			checked_at: checkedAt,
 			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});
-		await context.locals.emdash.setPluginStatus(receipt.plugin_id, "active");
 		return jsonResponse(receipt, 201);
 	} catch (error) {
 		return handleError(

--- a/apps/site/src/pages/_superboard/api/plugins/user/install.ts
+++ b/apps/site/src/pages/_superboard/api/plugins/user/install.ts
@@ -4,7 +4,10 @@ import { handleError } from "emdash/api/error";
 import { jsonResponse, requireReleaseOperator } from "../../../../../lib/operator-guard.js";
 import { isRecord } from "../../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../../lib/site-env.js";
-import { resolveSuperBoardPluginTarget } from "../../../../../lib/superboard-plugin-catalog.js";
+import {
+	resolveSuperBoardPluginTarget,
+	resolveSuperBoardTargetPluginIds,
+} from "../../../../../lib/superboard-plugin-catalog.js";
 import { installCompiledUserPlugin } from "../../../../../lib/user-plugin-installation.js";
 
 export const prerender = false;
@@ -34,6 +37,8 @@ export const POST: APIRoute = async (context) => {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
 			approved_by: operatorId,
+			target_artifact_checksum: env.TARGET_ARTIFACT_CHECKSUM,
+			target_plugin_ids: resolveSuperBoardTargetPluginIds(env.SUPERBOARD_PLUGIN_IDS),
 			checked_at: checkedAt,
 			expires_at: new Date(Date.parse(checkedAt) + expiresInHours * 60 * 60 * 1_000).toISOString(),
 		});

--- a/apps/site/src/pages/_superboard/api/releases/activate.ts
+++ b/apps/site/src/pages/_superboard/api/releases/activate.ts
@@ -17,6 +17,10 @@ import {
 import { loadLastVerifiedFrontRelease } from "../../../../lib/release-source.js";
 import { isRecord } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
+import {
+	reconcileSuperBoardPluginLifecycleForRelease,
+	resolveSuperBoardPluginTarget,
+} from "../../../../lib/superboard-plugin-catalog.js";
 
 export const prerender = false;
 
@@ -82,5 +86,18 @@ export const POST: APIRoute = async (context) => {
 	if (!loaded || loaded.release.payload.release_id !== result.active_release_id) {
 		return jsonResponse({ error: { code: "LAST_VERIFIED_CACHE_RELOAD_FAILED" } }, 500);
 	}
-	return jsonResponse(result, 201);
+	const pluginLifecycle = await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+		instance_id: env.SUPERBOARD_INSTANCE_ID,
+		target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT),
+		release_id: loaded.release.payload.release_id,
+		plugin_lock: loaded.release.payload.plugin_lock,
+		activated_at: activatedAt,
+	});
+	for (const pluginId of pluginLifecycle.activated_plugin_ids) {
+		await context.locals.emdash.setPluginStatus(pluginId, "active");
+	}
+	for (const pluginId of pluginLifecycle.disabled_plugin_ids) {
+		await context.locals.emdash.setPluginStatus(pluginId, "inactive");
+	}
+	return jsonResponse({ ...result, plugin_lifecycle: pluginLifecycle }, 201);
 };

--- a/apps/site/src/pages/_superboard/api/releases/activate.ts
+++ b/apps/site/src/pages/_superboard/api/releases/activate.ts
@@ -18,7 +18,8 @@ import { loadLastVerifiedFrontRelease } from "../../../../lib/release-source.js"
 import { isRecord } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
 import {
-	reconcileSuperBoardPluginLifecycleForRelease,
+	finalizeSuperBoardPluginLifecycleForRelease,
+	prepareSuperBoardPluginLifecycleForRelease,
 	resolveSuperBoardPluginTarget,
 } from "../../../../lib/superboard-plugin-catalog.js";
 
@@ -60,6 +61,14 @@ export const POST: APIRoute = async (context) => {
 	if (!reauthentication) {
 		return jsonResponse({ error: { code: "STRONG_REAUTH_REQUIRED" } }, 403);
 	}
+	const pluginTarget = resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT);
+	await prepareSuperBoardPluginLifecycleForRelease(env.DB, {
+		instance_id: env.SUPERBOARD_INSTANCE_ID,
+		target: pluginTarget,
+		release_id: candidate.release.payload.release_id,
+		plugin_lock: candidate.release.payload.plugin_lock,
+		prepared_at: activatedAt,
+	});
 	const result = await activateFrontRelease(createD1FrontReleaseRepository(env.DB), {
 		instance_id: env.SUPERBOARD_INSTANCE_ID,
 		candidate_id: body.candidate_id,
@@ -86,12 +95,11 @@ export const POST: APIRoute = async (context) => {
 	if (!loaded || loaded.release.payload.release_id !== result.active_release_id) {
 		return jsonResponse({ error: { code: "LAST_VERIFIED_CACHE_RELOAD_FAILED" } }, 500);
 	}
-	const pluginLifecycle = await reconcileSuperBoardPluginLifecycleForRelease(env.DB, {
+	const pluginLifecycle = await finalizeSuperBoardPluginLifecycleForRelease(env.DB, {
 		instance_id: env.SUPERBOARD_INSTANCE_ID,
-		target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT),
+		target: pluginTarget,
 		release_id: loaded.release.payload.release_id,
-		plugin_lock: loaded.release.payload.plugin_lock,
-		activated_at: activatedAt,
+		finalized_at: activatedAt,
 	});
 	for (const pluginId of pluginLifecycle.activated_plugin_ids) {
 		await context.locals.emdash.setPluginStatus(pluginId, "active");

--- a/apps/site/src/pages/_superboard/api/releases/rollback.ts
+++ b/apps/site/src/pages/_superboard/api/releases/rollback.ts
@@ -14,6 +14,11 @@ import { createD1FrontReleaseRepository } from "../../../../lib/release-reposito
 import { loadLastVerifiedFrontRelease } from "../../../../lib/release-source.js";
 import { isRecord } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
+import {
+	finalizeSuperBoardPluginLifecycleForRelease,
+	prepareSuperBoardPluginLifecycleForRelease,
+	resolveSuperBoardPluginTarget,
+} from "../../../../lib/superboard-plugin-catalog.js";
 
 export const prerender = false;
 
@@ -54,6 +59,14 @@ export const POST: APIRoute = async (context) => {
 			409,
 		);
 	}
+	const pluginTarget = resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT);
+	await prepareSuperBoardPluginLifecycleForRelease(env.DB, {
+		instance_id: env.SUPERBOARD_INSTANCE_ID,
+		target: pluginTarget,
+		release_id: target.release.payload.release_id,
+		plugin_lock: target.release.payload.plugin_lock,
+		prepared_at: now,
+	});
 	const result = await repository.compareAndSwapActive({
 		candidate: target,
 		command: {
@@ -68,6 +81,24 @@ export const POST: APIRoute = async (context) => {
 	});
 	if (result.status !== "activated") return jsonResponse({ error: result }, 409);
 	await env.RELEASE_CACHE.delete(`last_verified_release:${env.SUPERBOARD_INSTANCE_ID}`);
-	await loadLastVerifiedFrontRelease(env, env.SUPERBOARD_INSTANCE_ID);
-	return jsonResponse({ ...result, rollback: "pointer_only" }, 201);
+	const loaded = await loadLastVerifiedFrontRelease(env, env.SUPERBOARD_INSTANCE_ID);
+	if (!loaded || loaded.release.payload.release_id !== result.active_release_id) {
+		return jsonResponse({ error: { code: "LAST_VERIFIED_CACHE_RELOAD_FAILED" } }, 500);
+	}
+	const pluginLifecycle = await finalizeSuperBoardPluginLifecycleForRelease(env.DB, {
+		instance_id: env.SUPERBOARD_INSTANCE_ID,
+		target: pluginTarget,
+		release_id: loaded.release.payload.release_id,
+		finalized_at: now,
+	});
+	for (const pluginId of pluginLifecycle.activated_plugin_ids) {
+		await context.locals.emdash.setPluginStatus(pluginId, "active");
+	}
+	for (const pluginId of pluginLifecycle.disabled_plugin_ids) {
+		await context.locals.emdash.setPluginStatus(pluginId, "inactive");
+	}
+	return jsonResponse(
+		{ ...result, rollback: "pointer_only", plugin_lifecycle: pluginLifecycle },
+		201,
+	);
 };

--- a/apps/site/src/pages/_superboard/api/releases/user-slice.ts
+++ b/apps/site/src/pages/_superboard/api/releases/user-slice.ts
@@ -9,7 +9,10 @@ import { jsonResponse, requireReleaseOperator } from "../../../../lib/operator-g
 import { createD1FrontReleaseRepository } from "../../../../lib/release-repository.js";
 import { isRecord, isUlid } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
-import { loadActiveSuperBoardPluginLock } from "../../../../lib/superboard-plugin-catalog.js";
+import {
+	loadActiveSuperBoardPluginLock,
+	resolveSuperBoardPluginTarget,
+} from "../../../../lib/superboard-plugin-catalog.js";
 import { composeUserFrontReleaseInput } from "../../../../lib/user-front-release.js";
 
 export const prerender = false;
@@ -48,7 +51,10 @@ export const POST: APIRoute = async (context) => {
 		}
 		const releaseSequence = (predecessor?.release.payload.release_sequence ?? 0) + 1;
 		const previousReleaseId = active?.active_release_id ?? null;
-		const pluginLock = await loadActiveSuperBoardPluginLock(env.DB);
+		const pluginLock = await loadActiveSuperBoardPluginLock(env.DB, {
+			instance_id: env.SUPERBOARD_INSTANCE_ID,
+			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
+		});
 		const input = await composeUserFrontReleaseInput({
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			...identifiers,

--- a/apps/site/src/pages/_superboard/api/releases/user-slice.ts
+++ b/apps/site/src/pages/_superboard/api/releases/user-slice.ts
@@ -10,7 +10,7 @@ import { createD1FrontReleaseRepository } from "../../../../lib/release-reposito
 import { isRecord, isUlid } from "../../../../lib/request-validation.js";
 import { getSiteEnv } from "../../../../lib/site-env.js";
 import {
-	loadActiveSuperBoardPluginLock,
+	loadReleasableSuperBoardPluginLock,
 	resolveSuperBoardPluginTarget,
 } from "../../../../lib/superboard-plugin-catalog.js";
 import { composeUserFrontReleaseInput } from "../../../../lib/user-front-release.js";
@@ -51,7 +51,7 @@ export const POST: APIRoute = async (context) => {
 		}
 		const releaseSequence = (predecessor?.release.payload.release_sequence ?? 0) + 1;
 		const previousReleaseId = active?.active_release_id ?? null;
-		const pluginLock = await loadActiveSuperBoardPluginLock(env.DB, {
+		const pluginLock = await loadReleasableSuperBoardPluginLock(env.DB, {
 			instance_id: env.SUPERBOARD_INSTANCE_ID,
 			target: resolveSuperBoardPluginTarget(env.SUPERBOARD_ENVIRONMENT ?? "local"),
 		});

--- a/apps/site/superboard-emdash-plugins.mjs
+++ b/apps/site/superboard-emdash-plugins.mjs
@@ -27,6 +27,7 @@ export function configureSuperBoardPlugins(plugins) {
 				id: manifest.plugin_id,
 				version,
 				defaultEnabled: false,
+				lifecycleManaged: true,
 				entrypoint,
 				adminPages: [{ path: "/", label: displayName, icon: "settings" }],
 				settingsSchema,

--- a/apps/site/superboard-emdash-plugins.mjs
+++ b/apps/site/superboard-emdash-plugins.mjs
@@ -10,12 +10,9 @@ export const SUPERBOARD_PLUGIN_TEMPLATES = Object.freeze(
 		.toSorted(),
 );
 
-export const superboardConfiguredPlugins = Object.freeze(
-	topology.plugins
-		.filter(({ manifest, worker_descriptor: descriptor }) => {
-			if (manifest.plugin_id.includes("*")) return false;
-			return manifest.plugin_kind === "full" || descriptor?.deployment_status === "ready";
-		})
+export function configureSuperBoardPlugins(plugins) {
+	return plugins
+		.filter(({ manifest }) => !manifest.plugin_id.includes("*"))
 		.map(({ manifest }) => {
 			const version = VERSION_OVERRIDES[manifest.plugin_id] ?? manifest.plugin_version;
 			const displayName = pluginDisplayName(manifest.plugin_id);
@@ -29,6 +26,7 @@ export const superboardConfiguredPlugins = Object.freeze(
 			return {
 				id: manifest.plugin_id,
 				version,
+				defaultEnabled: false,
 				entrypoint,
 				adminPages: [{ path: "/", label: displayName, icon: "settings" }],
 				settingsSchema,
@@ -50,7 +48,11 @@ export const superboardConfiguredPlugins = Object.freeze(
 				],
 				superboardManifest: manifest,
 			};
-		}),
+		});
+}
+
+export const superboardConfiguredPlugins = Object.freeze(
+	configureSuperBoardPlugins(topology.plugins),
 );
 
 function emdashSettingsSchema(properties) {

--- a/apps/site/superboard-emdash-plugins.test.mjs
+++ b/apps/site/superboard-emdash-plugins.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import topology from "../../config/emdash-plugin-topology.json" with { type: "json" };
 import {
 	SUPERBOARD_PLUGIN_TEMPLATES,
+	configureSuperBoardPlugins,
 	superboardConfiguredPlugins,
 } from "./superboard-emdash-plugins.mjs";
 
@@ -22,20 +23,19 @@ test("adapts every concrete SuperBoard manifest into one configured EmDash plugi
 	assert.ok(superboardConfiguredPlugins.every(({ id }) => !id.includes("*")));
 });
 
-test("does not register a module whose Worker descriptor is not ready", () => {
-	const readyModuleIds = topology.plugins
-		.filter(
-			({ manifest, worker_descriptor: descriptor }) =>
-				manifest.plugin_kind === "module" && descriptor?.deployment_status === "ready",
-		)
-		.map(({ manifest }) => manifest.plugin_id)
-		.toSorted();
+test("keeps a module available in the catalog while its Worker is not ready", () => {
+	const module = topology.plugins.find(
+		({ manifest }) => manifest.plugin_id === "supbrd-plugmod-analytics",
+	);
+	const configured = configureSuperBoardPlugins([
+		{
+			...module,
+			worker_descriptor: { ...module.worker_descriptor, deployment_status: "not_ready" },
+		},
+	]);
 	assert.deepEqual(
-		superboardConfiguredPlugins
-			.filter(({ id }) => id.startsWith("supbrd-plugmod-"))
-			.map(({ id }) => id)
-			.toSorted(),
-		readyModuleIds,
+		configured.map(({ id }) => id),
+		["supbrd-plugmod-analytics"],
 	);
 });
 

--- a/apps/site/worker-configuration.d.ts
+++ b/apps/site/worker-configuration.d.ts
@@ -11,6 +11,7 @@ interface __BaseEnv_Env {
 	IMAGES: ImagesBinding;
 	ASSETS: Fetcher;
 	SUPERBOARD_INSTANCE_ID: string;
+	SUPERBOARD_ENVIRONMENT: string;
 	SUPERBOARD_RELEASE_OPERATIONS: string;
 	D1_EXPECTED_MIGRATION: string;
 	EMDASH_ENCRYPTION_KEY: string;
@@ -26,7 +27,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "SUPERBOARD_INSTANCE_ID" | "SUPERBOARD_RELEASE_OPERATIONS" | "D1_EXPECTED_MIGRATION" | "EMDASH_ENCRYPTION_KEY" | "SITE_OPERATOR_BRIDGE_TOKEN" | "SUPERBOARD_PLUGIN_STORE_ENCRYPTION_KEY">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "SUPERBOARD_INSTANCE_ID" | "SUPERBOARD_ENVIRONMENT" | "SUPERBOARD_RELEASE_OPERATIONS" | "D1_EXPECTED_MIGRATION" | "EMDASH_ENCRYPTION_KEY" | "SITE_OPERATOR_BRIDGE_TOKEN" | "SUPERBOARD_PLUGIN_STORE_ENCRYPTION_KEY">> {}
 }
 
 // Begin runtime types

--- a/apps/site/worker-configuration.d.ts
+++ b/apps/site/worker-configuration.d.ts
@@ -12,7 +12,9 @@ interface __BaseEnv_Env {
 	ASSETS: Fetcher;
 	SUPERBOARD_INSTANCE_ID: string;
 	SUPERBOARD_ENVIRONMENT: string;
+	SUPERBOARD_PLUGIN_IDS: string;
 	SUPERBOARD_RELEASE_OPERATIONS: string;
+	TARGET_ARTIFACT_CHECKSUM: string;
 	D1_EXPECTED_MIGRATION: string;
 	EMDASH_ENCRYPTION_KEY: string;
 	SITE_OPERATOR_BRIDGE_TOKEN: string;
@@ -27,7 +29,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "SUPERBOARD_INSTANCE_ID" | "SUPERBOARD_ENVIRONMENT" | "SUPERBOARD_RELEASE_OPERATIONS" | "D1_EXPECTED_MIGRATION" | "EMDASH_ENCRYPTION_KEY" | "SITE_OPERATOR_BRIDGE_TOKEN" | "SUPERBOARD_PLUGIN_STORE_ENCRYPTION_KEY">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "SUPERBOARD_INSTANCE_ID" | "SUPERBOARD_ENVIRONMENT" | "SUPERBOARD_PLUGIN_IDS" | "SUPERBOARD_RELEASE_OPERATIONS" | "TARGET_ARTIFACT_CHECKSUM" | "D1_EXPECTED_MIGRATION" | "EMDASH_ENCRYPTION_KEY" | "SITE_OPERATOR_BRIDGE_TOKEN" | "SUPERBOARD_PLUGIN_STORE_ENCRYPTION_KEY">> {}
 }
 
 // Begin runtime types

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -67,8 +67,8 @@
 		"SUPERBOARD_INSTANCE_ID": "mbza-development",
 		"SUPERBOARD_ENVIRONMENT": "local",
 		"SUPERBOARD_RELEASE_OPERATIONS": "disabled",
-		"D1_EXPECTED_MIGRATION": "0018_native_front_view_bindings.sql",
-		"TARGET_ARTIFACT_CHECKSUM": "sha256:e0abcd3485c04787c5a8ea348828077c12f7af5dd5af5714c76730e9ba4d02c7",
+		"D1_EXPECTED_MIGRATION": "0019_data_driven_plugin_lifecycle.sql",
+		"TARGET_ARTIFACT_CHECKSUM": "sha256:3dfdf6401706baed96352b9958109d2c32f87e32b6b346b1519fa00e1c7523e6",
 	},
 	"triggers": {
 		"crons": ["* * * * *"],

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -65,6 +65,7 @@
 	},
 	"vars": {
 		"SUPERBOARD_INSTANCE_ID": "mbza-development",
+		"SUPERBOARD_ENVIRONMENT": "local",
 		"SUPERBOARD_RELEASE_OPERATIONS": "disabled",
 		"D1_EXPECTED_MIGRATION": "0018_native_front_view_bindings.sql",
 		"TARGET_ARTIFACT_CHECKSUM": "sha256:e0abcd3485c04787c5a8ea348828077c12f7af5dd5af5714c76730e9ba4d02c7",

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -66,9 +66,10 @@
 	"vars": {
 		"SUPERBOARD_INSTANCE_ID": "mbza-development",
 		"SUPERBOARD_ENVIRONMENT": "local",
+		"SUPERBOARD_PLUGIN_IDS": "[\"supbrd-plug-audit\",\"supbrd-plug-content\",\"supbrd-plug-products\",\"supbrd-plug-settings\",\"supbrd-plug-user\",\"supbrd-plugmod-analytics\",\"supbrd-plugmod-billing\",\"supbrd-plugmod-dynamic-links\",\"supbrd-plugmod-email\",\"supbrd-plugmod-files\",\"supbrd-plugmod-flows\",\"supbrd-plugmod-gateway\",\"supbrd-plugmod-marketing\",\"supbrd-plugmod-mcp\",\"supbrd-plugmod-observability\",\"supbrd-plugmod-support\"]",
 		"SUPERBOARD_RELEASE_OPERATIONS": "disabled",
 		"D1_EXPECTED_MIGRATION": "0019_data_driven_plugin_lifecycle.sql",
-		"TARGET_ARTIFACT_CHECKSUM": "sha256:3dfdf6401706baed96352b9958109d2c32f87e32b6b346b1519fa00e1c7523e6",
+		"TARGET_ARTIFACT_CHECKSUM": "sha256:bc55c4aa0e9f5a408776d3c9b9ae1dd0295f5b6544506c4ea1198d74ebc02da8",
 	},
 	"triggers": {
 		"crons": ["* * * * *"],

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -154,7 +154,7 @@ Native plugins:
 
 ### Keep a configured plugin inactive
 
-Sandboxed plugins in `sandboxed: []` are enabled when no persisted lifecycle state exists. Set `defaultEnabled: false` when a site needs to catalog a plugin before an administrator enables it.
+Sandboxed plugins in `sandboxed: []` are enabled when no persisted lifecycle state exists. Set `defaultEnabled: false` when a site needs to catalog a plugin before activation. Set `lifecycleManaged: true` when a host workflow must also reject the generic enable and disable actions in **Plugins**.
 
 The following configuration catalogs the webhook notifier while keeping its hooks and routes inactive:
 
@@ -166,13 +166,15 @@ import webhookNotifier from "@emdash-cms/plugin-webhook-notifier";
 export default defineConfig({
   integrations: [
     emdash({
-      sandboxed: [{ ...webhookNotifier, defaultEnabled: false }],
+      sandboxed: [
+        { ...webhookNotifier, defaultEnabled: false, lifecycleManaged: true },
+      ],
     }),
   ],
 });
 ```
 
-An administrator can enable the plugin from **Plugins**. Persisted active or inactive state takes precedence over `defaultEnabled` on later starts.
+The host workflow must persist the active or inactive state for this plugin. Persisted state takes precedence over `defaultEnabled` on later starts.
 
 ## Marketplace vs. config — when to use which
 

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -152,6 +152,28 @@ Native plugins:
   Use native plugins only when you need features that require build-time integration: React admin pages, Portable Text rendering components, or page fragment injection. For everything else, prefer sandboxed plugins -- they can be installed, updated, and removed from the admin panel.
 </Aside>
 
+### Keep a configured plugin inactive
+
+Sandboxed plugins in `sandboxed: []` are enabled when no persisted lifecycle state exists. Set `defaultEnabled: false` when a site needs to catalog a plugin before an administrator enables it.
+
+The following configuration catalogs the webhook notifier while keeping its hooks and routes inactive:
+
+```javascript title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import webhookNotifier from "@emdash-cms/plugin-webhook-notifier";
+
+export default defineConfig({
+  integrations: [
+    emdash({
+      sandboxed: [{ ...webhookNotifier, defaultEnabled: false }],
+    }),
+  ],
+});
+```
+
+An administrator can enable the plugin from **Plugins**. Persisted active or inactive state takes precedence over `defaultEnabled` on later starts.
+
 ## Marketplace vs. config — when to use which
 
 | | Marketplace (sandboxed) | Config (native or in-process sandboxed) |

--- a/packages/core/src/api/handlers/plugins.ts
+++ b/packages/core/src/api/handlers/plugins.ts
@@ -25,6 +25,8 @@ export interface PluginInfo {
 	source?: "config" | "marketplace" | "registry";
 	/** True for statically-sandboxed plugins (registered via `sandboxed: []`) */
 	sandboxed?: boolean;
+	/** True when the host owns activation outside generic plugin actions. */
+	lifecycleManaged?: boolean;
 	marketplaceVersion?: string;
 	/** Publisher DID, for registry-source plugins */
 	registryPublisherDid?: string;
@@ -137,6 +139,7 @@ function buildSandboxedPluginInfo(
 		status,
 		source: "config",
 		sandboxed: true,
+		lifecycleManaged: entry.lifecycleManaged ?? false,
 		capabilities: entry.capabilities,
 		hasAdminPages: (entry.adminPages?.length ?? 0) > 0,
 		hasDashboardWidgets: (entry.adminWidgets?.length ?? 0) > 0,
@@ -341,6 +344,15 @@ export async function handlePluginEnable(
 		// Statically-sandboxed plugin: addressable via its build-time entry.
 		const sandboxed = sandboxedPluginEntries.find((e) => e.id === pluginId);
 		if (sandboxed) {
+			if (sandboxed.lifecycleManaged) {
+				return {
+					success: false,
+					error: {
+						code: "VALIDATION_ERROR",
+						message: "Plugin activation is managed by the host",
+					},
+				};
+			}
 			const state = await stateRepo.enable(pluginId, sandboxed.version);
 			return { success: true, data: { item: buildSandboxedPluginInfo(sandboxed, state) } };
 		}
@@ -388,6 +400,15 @@ export async function handlePluginDisable(
 
 		const sandboxed = sandboxedPluginEntries.find((e) => e.id === pluginId);
 		if (sandboxed) {
+			if (sandboxed.lifecycleManaged) {
+				return {
+					success: false,
+					error: {
+						code: "VALIDATION_ERROR",
+						message: "Plugin deactivation is managed by the host",
+					},
+				};
+			}
 			const state = await stateRepo.disable(pluginId, sandboxed.version);
 			return { success: true, data: { item: buildSandboxedPluginInfo(sandboxed, state) } };
 		}

--- a/packages/core/src/api/handlers/plugins.ts
+++ b/packages/core/src/api/handlers/plugins.ts
@@ -6,7 +6,12 @@ import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
 import type { SandboxedPluginEntry } from "../../emdash-runtime.js";
-import { PluginStateRepository, type PluginState, type PluginStatus } from "../../plugins/state.js";
+import {
+	isPluginStateEnabled,
+	PluginStateRepository,
+	type PluginState,
+	type PluginStatus,
+} from "../../plugins/state.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import type { ApiResult } from "../types.js";
 
@@ -120,8 +125,8 @@ function buildSandboxedPluginInfo(
 	entry: SandboxedPluginEntry,
 	state: PluginState | null,
 ): PluginInfo {
-	const status = state?.status ?? (entry.defaultEnabled === false ? "inactive" : "active");
-	const enabled = status === "active";
+	const enabled = isPluginStateEnabled(state?.status, entry.defaultEnabled);
+	const status = state?.status ?? (enabled ? "active" : "inactive");
 
 	return {
 		id: entry.id,

--- a/packages/core/src/api/handlers/plugins.ts
+++ b/packages/core/src/api/handlers/plugins.ts
@@ -120,7 +120,7 @@ function buildSandboxedPluginInfo(
 	entry: SandboxedPluginEntry,
 	state: PluginState | null,
 ): PluginInfo {
-	const status = state?.status ?? "active";
+	const status = state?.status ?? (entry.defaultEnabled === false ? "inactive" : "active");
 	const enabled = status === "active";
 
 	return {

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -80,6 +80,8 @@ export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 	id: string;
 	/** Plugin version (semver) */
 	version: string;
+	/** Whether code presence enables the plugin when no persisted lifecycle state exists. */
+	defaultEnabled?: boolean;
 	/** Module specifier to import (e.g., "@emdash-cms/plugin-api-test") */
 	entrypoint: string;
 	/**

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -82,6 +82,8 @@ export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 	version: string;
 	/** Whether code presence enables the plugin when no persisted lifecycle state exists. */
 	defaultEnabled?: boolean;
+	/** Whether the host owns activation and rejects generic admin enable/disable actions. */
+	lifecycleManaged?: boolean;
 	/** Module specifier to import (e.g., "@emdash-cms/plugin-api-test") */
 	entrypoint: string;
 	/**

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -693,6 +693,7 @@ export const sandboxedPlugins = [];
     id: ${JSON.stringify(descriptor.id)},
     version: ${JSON.stringify(descriptor.version)},
     defaultEnabled: ${JSON.stringify(descriptor.defaultEnabled ?? true)},
+    lifecycleManaged: ${JSON.stringify(descriptor.lifecycleManaged ?? false)},
     options: ${JSON.stringify(descriptor.options ?? {})},
     capabilities: ${JSON.stringify(descriptor.capabilities ?? [])},
     allowedHosts: ${JSON.stringify(descriptor.allowedHosts ?? [])},

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -692,6 +692,7 @@ export const sandboxedPlugins = [];
 		pluginEntries.push(`{
     id: ${JSON.stringify(descriptor.id)},
     version: ${JSON.stringify(descriptor.version)},
+    defaultEnabled: ${JSON.stringify(descriptor.defaultEnabled ?? true)},
     options: ${JSON.stringify(descriptor.options ?? {})},
     capabilities: ${JSON.stringify(descriptor.capabilities ?? [])},
     allowedHosts: ${JSON.stringify(descriptor.allowedHosts ?? [])},

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -269,6 +269,8 @@ export interface SandboxedPluginEntry {
 	version: string;
 	/** Build-time default used only when no persisted plugin state exists. */
 	defaultEnabled?: boolean;
+	/** Host-owned lifecycle blocks generic admin enable/disable actions. */
+	lifecycleManaged?: boolean;
 	options: Record<string, unknown>;
 	code: string;
 	/** Capabilities the plugin requests */

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -217,7 +217,7 @@ import {
 	type RouteMeta,
 } from "./plugins/routes.js";
 import type { CronScheduler } from "./plugins/scheduler/types.js";
-import { PluginStateRepository } from "./plugins/state.js";
+import { isPluginStateEnabled, PluginStateRepository } from "./plugins/state.js";
 import { syncDeclaredStorageIndexes } from "./plugins/storage-indexes.js";
 import { normalizeRegistryConfig } from "./registry/config.js";
 import { requestCached } from "./request-cache.js";
@@ -1517,7 +1517,7 @@ export class EmDashRuntime {
 				// Persisted state overrides the descriptor's missing-state default.
 				const status = pluginStates.get(plugin.id);
 				const configured = deps.sandboxedPluginEntries.find((entry) => entry.id === plugin.id);
-				if (status === "active" || (status === undefined && configured?.defaultEnabled !== false)) {
+				if (isPluginStateEnabled(status, configured?.defaultEnabled)) {
 					enabledPlugins.add(plugin.id);
 				}
 			}
@@ -2588,8 +2588,7 @@ export class EmDashRuntime {
 		// Add sandboxed plugins (use entries for admin config)
 		for (const entry of this.sandboxedPluginEntries) {
 			const status = this.pluginStates.get(entry.id);
-			const enabled =
-				status === "active" || (status === undefined && entry.defaultEnabled !== false);
+			const enabled = isPluginStateEnabled(status, entry.defaultEnabled);
 
 			const hasAdminPages = (entry.adminPages?.length ?? 0) > 0;
 			const hasWidgets = (entry.adminWidgets?.length ?? 0) > 0;
@@ -4368,9 +4367,9 @@ export class EmDashRuntime {
 
 	private isPluginEnabled(pluginId: string): boolean {
 		const status = this.pluginStates.get(pluginId);
-		if (status !== undefined) return status === "active";
-		return (
-			this.sandboxedPluginEntries.find((entry) => entry.id === pluginId)?.defaultEnabled !== false
-		);
+		const defaultEnabled = this.sandboxedPluginEntries.find(
+			(entry) => entry.id === pluginId,
+		)?.defaultEnabled;
+		return isPluginStateEnabled(status, defaultEnabled);
 	}
 }

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -267,6 +267,8 @@ const LIST_COLUMN_FIELD_TYPES: ReadonlySet<FieldType> = new Set([
 export interface SandboxedPluginEntry {
 	id: string;
 	version: string;
+	/** Build-time default used only when no persisted plugin state exists. */
+	defaultEnabled?: boolean;
 	options: Record<string, unknown>;
 	code: string;
 	/** Capabilities the plugin requests */
@@ -1512,10 +1514,10 @@ export class EmDashRuntime {
 			for (const plugin of bypassedPlugins) {
 				allPipelinePlugins.push(plugin);
 				bypassedPluginsList.push(plugin);
-				// Respect plugin state: only enable if active or no record exists.
-				// Plugins an admin previously disabled should stay disabled.
+				// Persisted state overrides the descriptor's missing-state default.
 				const status = pluginStates.get(plugin.id);
-				if (status === undefined || status === "active") {
+				const configured = deps.sandboxedPluginEntries.find((entry) => entry.id === plugin.id);
+				if (status === "active" || (status === undefined && configured?.defaultEnabled !== false)) {
 					enabledPlugins.add(plugin.id);
 				}
 			}
@@ -2586,7 +2588,8 @@ export class EmDashRuntime {
 		// Add sandboxed plugins (use entries for admin config)
 		for (const entry of this.sandboxedPluginEntries) {
 			const status = this.pluginStates.get(entry.id);
-			const enabled = status === undefined || status === "active";
+			const enabled =
+				status === "active" || (status === undefined && entry.defaultEnabled !== false);
 
 			const hasAdminPages = (entry.adminPages?.length ?? 0) > 0;
 			const hasWidgets = (entry.adminWidgets?.length ?? 0) > 0;
@@ -4365,6 +4368,9 @@ export class EmDashRuntime {
 
 	private isPluginEnabled(pluginId: string): boolean {
 		const status = this.pluginStates.get(pluginId);
-		return status === undefined || status === "active";
+		if (status !== undefined) return status === "active";
+		return (
+			this.sandboxedPluginEntries.find((entry) => entry.id === pluginId)?.defaultEnabled !== false
+		);
 	}
 }

--- a/packages/core/src/plugins/state.ts
+++ b/packages/core/src/plugins/state.ts
@@ -12,6 +12,13 @@ import type { Database } from "../database/types.js";
 export type PluginStatus = "active" | "inactive";
 export type PluginSource = "config" | "marketplace" | "registry";
 
+export function isPluginStateEnabled(
+	status: string | undefined,
+	defaultEnabled: boolean = true,
+): boolean {
+	return status === "active" || (status === undefined && defaultEnabled);
+}
+
 function toPluginStatus(value: string): PluginStatus {
 	if (value === "active") return "active";
 	return "inactive";

--- a/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
+++ b/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
@@ -130,6 +130,14 @@ describe("admin plugin routes: statically-sandboxed plugins (real runtime)", () 
 		expect(plugin).toMatchObject({ source: "config", sandboxed: true, enabled: true });
 	});
 
+	it("keeps a catalogued sandboxed plugin inactive until it has lifecycle state", async () => {
+		runtime = buildRuntime(db, [sandboxedEntry({ defaultEnabled: false })]);
+		const body = await listIds(runtime);
+		const plugin = body.items.find((item) => item.id === "webhook-notifier");
+		expect(plugin).toMatchObject({ source: "config", sandboxed: true, enabled: false });
+		expect(runtime.getPluginRouteMeta("webhook-notifier", "admin")).toBeNull();
+	});
+
 	it("the enable and disable routes toggle a sandboxed plugin end to end", async () => {
 		const off = await disablePlugin(ctx(runtime, { id: "webhook-notifier" }));
 		expect(off.status).toBe(200);

--- a/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
+++ b/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
@@ -138,6 +138,19 @@ describe("admin plugin routes: statically-sandboxed plugins (real runtime)", () 
 		expect(runtime.getPluginRouteMeta("webhook-notifier", "admin")).toBeNull();
 	});
 
+	it("rejects generic activation for a host-managed plugin", async () => {
+		runtime = buildRuntime(db, [sandboxedEntry({ defaultEnabled: false, lifecycleManaged: true })]);
+		const enable = await enablePlugin(ctx(runtime, { id: "webhook-notifier" }));
+		expect(enable.status).toBe(400);
+		expect(await enable.json()).toMatchObject({
+			error: { code: "VALIDATION_ERROR", message: "Plugin activation is managed by the host" },
+		});
+		const disable = await disablePlugin(ctx(runtime, { id: "webhook-notifier" }));
+		expect(disable.status).toBe(400);
+		const body = await listIds(runtime);
+		expect(body.items.find((item) => item.id === "webhook-notifier")?.enabled).toBe(false);
+	});
+
 	it("the enable and disable routes toggle a sandboxed plugin end to end", async () => {
 		const off = await disablePlugin(ctx(runtime, { id: "webhook-notifier" }));
 		expect(off.status).toBe(200);

--- a/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
+++ b/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
@@ -67,12 +67,13 @@ describe("generateSandboxedPluginsModule", () => {
 		await setupFakeProject("dist/sandbox-entry.mjs", "export default { hooks: {} };");
 
 		const result = generateSandboxedPluginsModule(
-			[descriptor({ entrypoint: "@test/plugin/sandbox" })],
+			[descriptor({ entrypoint: "@test/plugin/sandbox", defaultEnabled: false })],
 			tmpDir,
 		);
 
 		expect(result).toContain("sandboxedPlugins");
 		expect(result).toContain("test-plugin");
+		expect(result).toContain("defaultEnabled: false");
 		expect(result).toContain("export default { hooks: {} };");
 	});
 

--- a/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
+++ b/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
@@ -67,13 +67,20 @@ describe("generateSandboxedPluginsModule", () => {
 		await setupFakeProject("dist/sandbox-entry.mjs", "export default { hooks: {} };");
 
 		const result = generateSandboxedPluginsModule(
-			[descriptor({ entrypoint: "@test/plugin/sandbox", defaultEnabled: false })],
+			[
+				descriptor({
+					entrypoint: "@test/plugin/sandbox",
+					defaultEnabled: false,
+					lifecycleManaged: true,
+				}),
+			],
 			tmpDir,
 		);
 
 		expect(result).toContain("sandboxedPlugins");
 		expect(result).toContain("test-plugin");
 		expect(result).toContain("defaultEnabled: false");
+		expect(result).toContain("lifecycleManaged: true");
 		expect(result).toContain("export default { hooks: {} };");
 	});
 

--- a/scripts/cloudflare-config.mjs
+++ b/scripts/cloudflare-config.mjs
@@ -246,6 +246,7 @@ function siteConfig() {
     assets: { binding: "ASSETS", directory: "../../apps/site/dist/client" },
     vars: {
       SUPERBOARD_INSTANCE_ID: target.target,
+      SUPERBOARD_ENVIRONMENT: environment,
       SUPERBOARD_RELEASE_OPERATIONS: siteReleaseOperations.value,
       ...d1SchemaVars(),
     },

--- a/scripts/cloudflare-config.mjs
+++ b/scripts/cloudflare-config.mjs
@@ -247,7 +247,13 @@ function siteConfig() {
     vars: {
       SUPERBOARD_INSTANCE_ID: target.target,
       SUPERBOARD_ENVIRONMENT: environment,
+      SUPERBOARD_PLUGIN_IDS: JSON.stringify(
+        compiledTarget.graph.plugins
+          .filter(({ pluginId }) => !pluginId.includes("*"))
+          .map(({ pluginId }) => pluginId),
+      ),
       SUPERBOARD_RELEASE_OPERATIONS: siteReleaseOperations.value,
+      TARGET_ARTIFACT_CHECKSUM: compiledTarget.checksum,
       ...d1SchemaVars(),
     },
     d1_databases: [

--- a/scripts/target-compiler.mjs
+++ b/scripts/target-compiler.mjs
@@ -284,6 +284,11 @@ export function compileLocalSiteConfiguration(compiledTarget) {
 		vars: {
 			SUPERBOARD_INSTANCE_ID: compiledTarget.target,
 			SUPERBOARD_ENVIRONMENT: compiledTarget.environment,
+			SUPERBOARD_PLUGIN_IDS: JSON.stringify(
+				compiledTarget.graph.plugins
+					.filter(({ pluginId }) => !pluginId.includes("*"))
+					.map(({ pluginId }) => pluginId),
+			),
 			SUPERBOARD_RELEASE_OPERATIONS: "disabled",
 			D1_EXPECTED_MIGRATION: siteMigration?.files.at(-1)?.file,
 			TARGET_ARTIFACT_CHECKSUM: compiledTarget.checksum,

--- a/scripts/target-compiler.mjs
+++ b/scripts/target-compiler.mjs
@@ -283,6 +283,7 @@ export function compileLocalSiteConfiguration(compiledTarget) {
 		secrets: { required: (siteSecrets?.names ?? []).toSorted() },
 		vars: {
 			SUPERBOARD_INSTANCE_ID: compiledTarget.target,
+			SUPERBOARD_ENVIRONMENT: compiledTarget.environment,
 			SUPERBOARD_RELEASE_OPERATIONS: "disabled",
 			D1_EXPECTED_MIGRATION: siteMigration?.files.at(-1)?.file,
 			TARGET_ARTIFACT_CHECKSUM: compiledTarget.checksum,

--- a/scripts/target-compiler.test.mjs
+++ b/scripts/target-compiler.test.mjs
@@ -94,6 +94,7 @@ test("the local Site configuration is generated and guarded by the target artifa
 		["SESSION", "RELEASE_CACHE"],
 	);
 	assert.equal(config.vars.SUPERBOARD_INSTANCE_ID, "mbza-development");
+	assert.equal(config.vars.SUPERBOARD_ENVIRONMENT, "local");
 	assert.match(config.vars.TARGET_ARTIFACT_CHECKSUM, CHECKSUM_PATTERN);
 	assertTargetServiceConfiguration(compiled, "site", config);
 

--- a/scripts/target-compiler.test.mjs
+++ b/scripts/target-compiler.test.mjs
@@ -95,6 +95,7 @@ test("the local Site configuration is generated and guarded by the target artifa
 	);
 	assert.equal(config.vars.SUPERBOARD_INSTANCE_ID, "mbza-development");
 	assert.equal(config.vars.SUPERBOARD_ENVIRONMENT, "local");
+	assert.equal(JSON.parse(config.vars.SUPERBOARD_PLUGIN_IDS).length, 16);
 	assert.match(config.vars.TARGET_ARTIFACT_CHECKSUM, CHECKSUM_PATTERN);
 	assertTargetServiceConfiguration(compiled, "site", config);
 


### PR DESCRIPTION
## What does this PR do?

Makes the SuperBoard plugin catalog and lifecycle data-driven for each Instance and compiled target. The 18 concrete manifests remain discoverable, while the `mbza-development` target installs its 16 compiled plugins and keeps disabled `paywalls` and `onboardings` in `available` state.

Installation now records a durable Plugin Installation Plan with per-plugin receipts for manifest, publisher, capabilities, Stores, migration graph, Worker descriptor, health, and release contract checks. The resulting Plugin Lock is bound to the current target artifact checksum. Front Release preparation and lifecycle application are guarded in D1, so the pointer swap, active plugin states, Store authority, dependency health, and release reconciliation commit atomically. Generic EmDash Admin enable/disable actions are rejected for host-managed plugins.

Closes #67

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: architecture approval is recorded in #46 and #64.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex, GPT-5.6

## Screenshots / test output

- `pnpm typecheck` passes across EmDash packages and SuperBoard services.
- Site typecheck passes with 0 errors and 0 warnings; Site tests pass (59 tests).
- Target compiler and Cloudflare configuration tests pass (34 tests in the final targeted run).
- Core lifecycle and virtual-module tests pass (12 tests); the documentation build passes.
- Targeted `oxlint` passes for all changed lifecycle and Core files. Repository-wide lint is blocked on `dev` by `sdks/flows/upstream/product/icons/.oxlintrc.json` extending a missing tracked config.
- The complete `pnpm test` run passes Core (6,174), Admin (1,757), Cloudflare, Workerd, Dashboard, API, Billing, Identity, Files, Observability, and MCP before reaching two pre-existing Products runtime assertions whose fixed reporting window ends on 2026-09-01. Those same two failures reproduce without #67 changes.
- Scoped `oxfmt` and Prettier were run on changed files. The repository-wide formatter was not run to avoid unrelated churn.
